### PR TITLE
Create teams and channels, assign users to teams and channels, frontend #33 #35

### DIFF
--- a/app/backend/Controllers/AddController.cs
+++ b/app/backend/Controllers/AddController.cs
@@ -22,8 +22,8 @@ public class AddController : ControllerBase
     [Authorize]
     public async Task<IActionResult> AddToTeam([FromBody] AddToTeamRequest req)
     {
-        Team team = await _context.Teams.FirstOrDefaultAsync(u => u.team_name == req.team_name);
-        if (team == null) // No team with such a name? Return error
+        Team team = await _context.Teams.FirstOrDefaultAsync(u => u.team_id == req.team_id);
+        if (team == null) // No team with the requested ID? Return error
         {
             return BadRequest(new { error = "Team not found" });
         }

--- a/app/backend/Controllers/AddController.cs
+++ b/app/backend/Controllers/AddController.cs
@@ -14,7 +14,8 @@ public class AddController : ControllerBase
 {
     private readonly ApplicationDbContext _context;
 
-    public AddController(ApplicationDbContext context) {
+    public AddController(ApplicationDbContext context)
+    {
         _context = context;
     }
 
@@ -51,19 +52,19 @@ public class AddController : ControllerBase
 
         return StatusCode(201, new { message = "User added to team successfully" });
     }
-    
+
     [HttpPost("addtochannel")]
     [Authorize]
     public async Task<IActionResult> AddToChannel([FromBody] AddToChannelRequest req)
     {
-        Team team = await _context.Teams.FirstOrDefaultAsync(u => u.team_name == req.team_name);
-        if (team == null)  // No team with such a name? Return error
+        Team team = await _context.Teams.FirstOrDefaultAsync(u => u.team_id == req.team_id);
+        if (team == null)  // No team with the requested ID? Return error
         {
             return BadRequest(new { error = "Team not found" });
         }
-        
-        Channel channel = await _context.Channels.FirstOrDefaultAsync(u => u.channel_name == req.channel_name && u.team_id == team.team_id);
-        if (channel == null)  // No channel with such a name within the team? Return error
+
+        Channel channel = await _context.Channels.FirstOrDefaultAsync(u => u.id == req.channel_id && u.team_id == team.team_id);
+        if (channel == null)  // No channel with the requested id within the team? Return error
         {
             return BadRequest(new { error = "Channel not found" });
         }
@@ -83,12 +84,12 @@ public class AddController : ControllerBase
             }
 
             ChannelMembership membership = await _context.ChannelMemberships.FirstOrDefaultAsync(m => m.user_id == user.user_id && m.channel_id == channel.id);
-            if (membership == null) // Already a member of the team? If not:
+            if (membership == null) // Already a member of the team but not a member of the channel
             {
                 membership = new ChannelMembership
                 {
                     user_id = user.user_id,
-                    channel_id = team.team_id,
+                    channel_id = channel.id,
                     created_at = DateTime.UtcNow
                 };
                 _context.ChannelMemberships.Add(membership); // Add user to channel

--- a/app/backend/Controllers/AddToChannelRequest.cs
+++ b/app/backend/Controllers/AddToChannelRequest.cs
@@ -1,6 +1,6 @@
 public class AddToChannelRequest
 {
-    public required string team_name { get; set; }
-    public required string channel_name { get; set; }
+    public required int team_id { get; set; }
+    public required int channel_id { get; set; }
     public required List<string> users_to_add {get; set;}
 }

--- a/app/backend/Controllers/AddToTeamRequest.cs
+++ b/app/backend/Controllers/AddToTeamRequest.cs
@@ -1,5 +1,5 @@
 public class AddToTeamRequest
 {
-    public required string team_name { get; set; }
+    public required int team_id { get; set; }
     public required List<string> users_to_add {get; set;}
 }

--- a/app/backend/Controllers/ChannelCreationRequest.cs
+++ b/app/backend/Controllers/ChannelCreationRequest.cs
@@ -1,5 +1,5 @@
 public class ChannelCreationRequest
 {
     public required string channel_name { get; set; }
-    public required string team_name { get; set; }
+    public required int team_id { get; set; }
 }

--- a/app/backend/Controllers/CreateController.cs
+++ b/app/backend/Controllers/CreateController.cs
@@ -87,8 +87,8 @@ public class CreateController : Controller
         using var transaction = await _context.Database.BeginTransactionAsync();
         try
         {
-            Team team = _context.Teams.FirstOrDefault(t => t.team_name == req.team_name);
-            if(team == null) // Is there a team with the given name? If not, return error
+            Team team = _context.Teams.FirstOrDefault(t => t.team_id == req.team_id);
+            if(team == null) // Is there a team with the given team_id? If not, return error.
                 return BadRequest(new { error = "Team not found" });
             
             var channel = new Channel { channel_name = req.channel_name, team_id = team.team_id };

--- a/app/frontend/package-lock.json
+++ b/app/frontend/package-lock.json
@@ -17,6 +17,7 @@
         "react": "^18.3.1",
         "react-dom": "^18.3.1",
         "react-router-dom": "^7.1.3",
+        "react-toastify": "^11.0.3",
         "wretch": "^2.11.0"
       },
       "devDependencies": {
@@ -3566,6 +3567,19 @@
       "peerDependencies": {
         "react": ">=18",
         "react-dom": ">=18"
+      }
+    },
+    "node_modules/react-toastify": {
+      "version": "11.0.3",
+      "resolved": "https://registry.npmjs.org/react-toastify/-/react-toastify-11.0.3.tgz",
+      "integrity": "sha512-cbPtHJPfc0sGqVwozBwaTrTu1ogB9+BLLjd4dDXd863qYLj7DGrQ2sg5RAChjFUB4yc3w8iXOtWcJqPK/6xqRQ==",
+      "license": "MIT",
+      "dependencies": {
+        "clsx": "^2.1.1"
+      },
+      "peerDependencies": {
+        "react": "^18 || ^19",
+        "react-dom": "^18 || ^19"
       }
     },
     "node_modules/react-transition-group": {

--- a/app/frontend/package.json
+++ b/app/frontend/package.json
@@ -19,6 +19,7 @@
     "react": "^18.3.1",
     "react-dom": "^18.3.1",
     "react-router-dom": "^7.1.3",
+    "react-toastify": "^11.0.3",
     "wretch": "^2.11.0"
   },
   "devDependencies": {

--- a/app/frontend/src/App.tsx
+++ b/app/frontend/src/App.tsx
@@ -11,6 +11,7 @@ import { createTheme, ThemeProvider } from "@mui/material";
 import Cookies from "js-cookie";
 import "./styles/App.css";
 import { useEffect, useState } from "react";
+import { ToastContainer } from "react-toastify";
 
 function App() {
   const [isAuthenticated, setIsAuthenticated] = useState(false);
@@ -37,6 +38,7 @@ function App() {
 
   return (
     <ThemeProvider theme={theme}>
+      <ToastContainer theme="dark" />
       <Router>
         <Routes>
           <Route

--- a/app/frontend/src/App.tsx
+++ b/app/frontend/src/App.tsx
@@ -26,6 +26,9 @@ function App() {
       primary: {
         main: "#559e6f",
       },
+      secondary: {
+        main: "#595c58",
+      },
       background: {
         paper: "#1e1e1e",
       },

--- a/app/frontend/src/components/ChannelListItem.tsx
+++ b/app/frontend/src/components/ChannelListItem.tsx
@@ -3,15 +3,17 @@ import {
   ListItemButton,
   ListItemIcon,
   ListItemText,
+  Tooltip,
 } from "@mui/material";
 import { IChannelModel } from "../models/models";
 import { useState } from "react";
-import PersonAddIcon from "@mui/icons-material/PersonAdd";
+import InviteToChannelButton from "./InviteToChannelButton";
 
 interface IChannelListItemProps {
   channel: IChannelModel;
   isUserAdmin: boolean;
   setSelectedChannel: (channel: IChannelModel) => void;
+  refetchData: () => void;
 }
 
 export default function ChannelListItem(props: IChannelListItemProps) {
@@ -38,9 +40,12 @@ export default function ChannelListItem(props: IChannelListItemProps) {
         slotProps={{ primary: { noWrap: true } }}
       />
       {areChannelActionsVisible && (
-        <IconButton sx={{ maxHeight: "24px", borderRadius: "4px" }} edge="end">
-          <PersonAddIcon />
-        </IconButton>
+        <InviteToChannelButton
+          teamId={props.channel.team_id}
+          channelId={props.channel.id}
+          channelName={props.channel.channel_name}
+          refetchData={props.refetchData}
+        />
       )}
     </ListItemButton>
   );

--- a/app/frontend/src/components/ChannelListItem.tsx
+++ b/app/frontend/src/components/ChannelListItem.tsx
@@ -1,0 +1,47 @@
+import {
+  IconButton,
+  ListItemButton,
+  ListItemIcon,
+  ListItemText,
+} from "@mui/material";
+import { IChannelModel } from "../models/models";
+import { useState } from "react";
+import PersonAddIcon from "@mui/icons-material/PersonAdd";
+
+interface IChannelListItemProps {
+  channel: IChannelModel;
+  isUserAdmin: boolean;
+  setSelectedChannel: (channel: IChannelModel) => void;
+}
+
+export default function ChannelListItem(props: IChannelListItemProps) {
+  const [areChannelActionsVisible, setAreChannelActionsVisible] =
+    useState<boolean>(false);
+
+  const handleHoverOverChannelItem = () => {
+    if (props.isUserAdmin) {
+      setAreChannelActionsVisible(true);
+    }
+  };
+
+  return (
+    <ListItemButton
+      className="channel-item"
+      key={props.channel.id}
+      onClick={() => props.setSelectedChannel(props.channel)}
+      onMouseOver={handleHoverOverChannelItem}
+      onMouseLeave={() => setAreChannelActionsVisible(false)}
+    >
+      <ListItemText
+        style={{ flexGrow: 1, width: "100%" }}
+        primary={props.channel.channel_name}
+        slotProps={{ primary: { noWrap: true } }}
+      />
+      {areChannelActionsVisible && (
+        <IconButton sx={{ maxHeight: "24px", borderRadius: "4px" }} edge="end">
+          <PersonAddIcon />
+        </IconButton>
+      )}
+    </ListItemButton>
+  );
+}

--- a/app/frontend/src/components/CreateChannelButton.tsx
+++ b/app/frontend/src/components/CreateChannelButton.tsx
@@ -13,6 +13,7 @@ import AddIcon from "@mui/icons-material/Add";
 import { useState } from "react";
 
 import wretch from "wretch";
+import { toast } from "react-toastify";
 
 interface ICreateChannelButtonProps {
   teamId: number;
@@ -31,9 +32,11 @@ export default function CreateChannelButton(props: ICreateChannelButtonProps) {
         .res(() => {
           setIsDialogOpen(false);
           props.refetchData();
+          toast.success("Team created successfully!");
         })
         .catch((error) => {
           console.error(error);
+          toast.error("An error has occurred.");
         });
     }
   };

--- a/app/frontend/src/components/CreateChannelButton.tsx
+++ b/app/frontend/src/components/CreateChannelButton.tsx
@@ -1,31 +1,33 @@
 import {
-  Tooltip,
-  IconButton,
-  Dialog,
-  DialogTitle,
-  DialogContent,
-  DialogActions,
-  TextField,
   Button,
+  Dialog,
+  DialogActions,
+  DialogContent,
+  DialogTitle,
+  IconButton,
+  TextField,
+  Tooltip,
 } from "@mui/material";
 import AddIcon from "@mui/icons-material/Add";
+
 import { useState } from "react";
 
 import wretch from "wretch";
 
-interface ICreateTeamButtonProps {
+interface ICreateChannelButtonProps {
+  teamId: number;
   refetchData: () => void;
 }
 
-export default function CreateTeamButton(props: ICreateTeamButtonProps) {
+export default function CreateChannelButton(props: ICreateChannelButtonProps) {
   const [isDialogOpen, setIsDialogOpen] = useState<boolean>(false);
-  const [teamName, setTeamName] = useState<string>("");
+  const [channelName, setChannelName] = useState<string>("");
 
   const onSubmit = () => {
-    if (teamName) {
-      wretch(`http://localhost:3001/api/create/team`)
+    if (channelName) {
+      wretch(`http://localhost:3001/api/create/channel`)
         .auth(`Bearer ${localStorage.getItem("jwt-token")}`)
-        .post({ team_name: teamName })
+        .post({ team_id: props.teamId, channel_name: channelName })
         .res(() => {
           setIsDialogOpen(false);
           props.refetchData();
@@ -35,11 +37,10 @@ export default function CreateTeamButton(props: ICreateTeamButtonProps) {
         });
     }
   };
-
   return (
     <>
       <Dialog open={isDialogOpen} onClose={() => setIsDialogOpen(false)}>
-        <DialogTitle>Create a team</DialogTitle>
+        <DialogTitle>Create a Channel</DialogTitle>
         <DialogContent
           sx={{
             minHeight: "100px",
@@ -47,10 +48,10 @@ export default function CreateTeamButton(props: ICreateTeamButtonProps) {
           }}
         >
           <TextField
-            label={"Team Name"}
-            title={"team_name"}
-            value={teamName}
-            onChange={(e) => setTeamName(e.target.value)}
+            label={"Channel Name"}
+            title={"channel_name"}
+            value={channelName}
+            onChange={(e) => setChannelName(e.target.value)}
           />
         </DialogContent>
         <DialogActions>
@@ -59,9 +60,12 @@ export default function CreateTeamButton(props: ICreateTeamButtonProps) {
           </Button>
         </DialogActions>
       </Dialog>
-      <Tooltip placement="right" title="Create a new team">
-        <IconButton onClick={() => setIsDialogOpen(true)}>
-          <AddIcon />
+      <Tooltip title="Create a channel">
+        <IconButton
+          sx={{ height: "52px", width: "47%" }}
+          onClick={() => setIsDialogOpen(true)}
+        >
+          <AddIcon></AddIcon>
         </IconButton>
       </Tooltip>
     </>

--- a/app/frontend/src/components/CreateTeamButton.tsx
+++ b/app/frontend/src/components/CreateTeamButton.tsx
@@ -39,7 +39,7 @@ export default function CreateTeamButton(props: ICreateTeamButtonProps) {
 
   return (
     <>
-      <Dialog open={isDialogOpen}>
+      <Dialog open={isDialogOpen} onClose={() => setIsDialogOpen(false)}>
         <DialogTitle>Create a team</DialogTitle>
         <DialogContent
           sx={{

--- a/app/frontend/src/components/CreateTeamButton.tsx
+++ b/app/frontend/src/components/CreateTeamButton.tsx
@@ -1,0 +1,70 @@
+import {
+  Tooltip,
+  IconButton,
+  Dialog,
+  DialogTitle,
+  DialogContent,
+  DialogActions,
+  TextField,
+  Button,
+} from "@mui/material";
+import AddIcon from "@mui/icons-material/Add";
+import { useState } from "react";
+
+import wretch from "wretch";
+
+interface ICreateTeamButtonProps {
+  refetchData: () => void;
+}
+
+export default function CreateTeamButton(props: ICreateTeamButtonProps) {
+  const [isDialogOpen, setIsDialogOpen] = useState<boolean>(false);
+  const [teamName, setTeamName] = useState<string>("");
+
+  const onSubmit = () => {
+    console.log(teamName);
+    if (teamName) {
+      wretch(`http://localhost:3001/api/create/team`)
+        .auth(`Bearer ${localStorage.getItem("jwt-token")}`)
+        .post({ team_name: teamName })
+        .res(() => {
+          setIsDialogOpen(false);
+          props.refetchData();
+        })
+        .catch((error) => {
+          console.error(error);
+        });
+    }
+  };
+
+  return (
+    <>
+      <Dialog open={isDialogOpen}>
+        <DialogTitle>Create a team</DialogTitle>
+        <DialogContent
+          sx={{
+            minHeight: "100px",
+            alignContent: "center",
+          }}
+        >
+          <TextField
+            label={"Team Name"}
+            title={"team_name"}
+            value={teamName}
+            onChange={(e) => setTeamName(e.target.value)}
+          />
+        </DialogContent>
+        <DialogActions>
+          <Button variant="contained" onClick={onSubmit}>
+            Create
+          </Button>
+        </DialogActions>
+      </Dialog>
+      <Tooltip placement="right" title="Create a new team">
+        <IconButton onClick={() => setIsDialogOpen(true)}>
+          <AddIcon />
+        </IconButton>
+      </Tooltip>
+    </>
+  );
+}

--- a/app/frontend/src/components/CreateTeamButton.tsx
+++ b/app/frontend/src/components/CreateTeamButton.tsx
@@ -12,6 +12,7 @@ import AddIcon from "@mui/icons-material/Add";
 import { useState } from "react";
 
 import wretch from "wretch";
+import { toast } from "react-toastify";
 
 interface ICreateTeamButtonProps {
   refetchData: () => void;
@@ -29,9 +30,12 @@ export default function CreateTeamButton(props: ICreateTeamButtonProps) {
         .res(() => {
           setIsDialogOpen(false);
           props.refetchData();
+          console.log("toast should run");
+          toast.success("Team created successfully!");
         })
         .catch((error) => {
           console.error(error);
+          toast.error("An error has occurred.");
         });
     }
   };

--- a/app/frontend/src/components/HomePage.tsx
+++ b/app/frontend/src/components/HomePage.tsx
@@ -1,5 +1,4 @@
 import {
-  Container,
   Button,
   useMediaQuery,
   useTheme,
@@ -9,7 +8,6 @@ import {
 } from "@mui/material";
 
 import { useEffect, useState } from "react";
-import Cookies from "js-cookie";
 import SideBar from "./SideBar";
 import { IChannelModel, ITeamModel, IUserModel } from "../models/models";
 
@@ -28,7 +26,12 @@ export default function HomePage() {
   const [tempTeamCount, setTempTeamCount] = useState<number>(1000);
   const [tempChannelsCount, setTempChannelsCount] = useState<number>(2000);
 
+  // retrieves data on home page load for the first time
   useEffect(() => {
+    fetchTeamAndChannelData();
+  }, []);
+
+  const fetchTeamAndChannelData = () => {
     wretch(`http://localhost:3001/api/home/index`)
       .auth(`Bearer ${localStorage.getItem("jwt-token")}`)
       .get()
@@ -36,7 +39,7 @@ export default function HomePage() {
         loadData(res),
       )
       .catch((err) => console.error(err));
-  }, []);
+  };
 
   const temporaryPopulateTeams = () => {
     setTeams((previous) =>
@@ -115,11 +118,6 @@ export default function HomePage() {
   const handleDrawerToggle = () => {
     setDrawerOpen(!drawerOpen);
   };
-  const logOut = () => {
-    Cookies.remove("isLoggedIn");
-    localStorage.removeItem("jwt-token");
-    window.location.href = "http://localhost:5173"; // modify this later probably
-  };
 
   const drawerVariant = isBrowser ? "permanent" : "temporary";
 
@@ -135,14 +133,16 @@ export default function HomePage() {
         drawerVariant={drawerVariant}
         drawerOpen={drawerOpen}
         handleDrawerToggle={handleDrawerToggle}
+        refetchData={fetchTeamAndChannelData}
       />
       <main
         style={{
           alignContent: "center",
           flexGrow: 1,
           padding: "16px",
-          margin: "8px",
+          margin: "6px",
           backgroundColor: "#18181880",
+          borderRadius: "4px",
         }}
       >
         <Grid container justifyContent={"center"} spacing={2}>
@@ -159,9 +159,6 @@ export default function HomePage() {
                 Click to populate the currently selected channel
               </Button>
             )}
-            <Button variant="contained" onClick={logOut}>
-              Log me out pls
-            </Button>
           </Grid>
           <Grid>
             <Typography variant={"body1"}>

--- a/app/frontend/src/components/HomePage.tsx
+++ b/app/frontend/src/components/HomePage.tsx
@@ -26,6 +26,8 @@ export default function HomePage() {
   const [tempTeamCount, setTempTeamCount] = useState<number>(1000);
   const [tempChannelsCount, setTempChannelsCount] = useState<number>(2000);
 
+  const [userData, setUserData] = useState<IUserModel>();
+
   // retrieves data on home page load for the first time
   useEffect(() => {
     fetchTeamAndChannelData();
@@ -35,9 +37,7 @@ export default function HomePage() {
     wretch(`http://localhost:3001/api/home/index`)
       .auth(`Bearer ${localStorage.getItem("jwt-token")}`)
       .get()
-      .json((res: { users: IUserModel[]; teams: ITeamModel[] }) =>
-        loadData(res),
-      )
+      .json((res: { user: IUserModel; teams: ITeamModel[] }) => loadData(res))
       .catch((err) => console.error(err));
   };
 
@@ -75,7 +75,9 @@ export default function HomePage() {
     setTempChannelsCount((previous) => previous + 3);
   };
 
-  const loadData = (data: { users: IUserModel[]; teams: ITeamModel[] }) => {
+  const loadData = (data: { user: IUserModel; teams: ITeamModel[] }) => {
+    const userData = data.user;
+
     const teamsData = data.teams.map((team: any) => ({
       team_id: team.team_id,
       team_name: team.team_name,
@@ -88,6 +90,7 @@ export default function HomePage() {
       })),
     );
 
+    setUserData(userData);
     setTeams(teamsData);
     setChannels(channelsData);
   };
@@ -124,6 +127,7 @@ export default function HomePage() {
   return (
     <Box style={{ display: "flex", height: "100vh", width: "100vw" }}>
       <SideBar
+        isUserAdmin={userData?.isAdmin ?? false}
         teams={teams}
         channels={channels}
         selectedTeam={selectedTeam}

--- a/app/frontend/src/components/InviteToChannelButton.tsx
+++ b/app/frontend/src/components/InviteToChannelButton.tsx
@@ -1,0 +1,91 @@
+import {
+  Button,
+  Dialog,
+  DialogActions,
+  DialogContent,
+  DialogTitle,
+  IconButton,
+  TextField,
+  Tooltip,
+} from "@mui/material";
+import PersonAddIcon from "@mui/icons-material/PersonAdd";
+
+import { useState } from "react";
+
+import wretch from "wretch";
+import { toast } from "react-toastify";
+
+interface IInviteToChannelButtonProps {
+  teamId: number;
+  channelId: number;
+  channelName: string;
+  refetchData: () => void;
+}
+
+export default function InviteToChannelButton(
+  props: IInviteToChannelButtonProps,
+) {
+  const [isDialogOpen, setIsDialogOpen] = useState<boolean>(false);
+  const [inviteeNames, setInviteeNames] = useState<string[]>([]);
+  const [currentUserName, setCurrentUserName] = useState<string>("");
+
+  const onSubmit = () => {
+    if (inviteeNames.length > 0) {
+      wretch(`http://localhost:3001/api/add/addtochannel`)
+        .auth(`Bearer ${localStorage.getItem("jwt-token")}`)
+        .post({
+          team_id: props.teamId,
+          channel_id: props.channelId,
+          users_to_add: inviteeNames,
+        })
+        .res(() => {
+          setIsDialogOpen(false);
+          props.refetchData();
+          toast.success("User(s) have been added successfully.");
+        })
+        .catch((error) => {
+          console.error(error);
+          toast.error("An error has occurred.");
+        });
+    }
+  };
+  return (
+    <>
+      <Dialog open={isDialogOpen} onClose={() => setIsDialogOpen(false)}>
+        <DialogTitle>Add users to {props.channelName}</DialogTitle>
+        <DialogContent
+          sx={{
+            minHeight: "100px",
+            alignContent: "center",
+          }}
+        >
+          <TextField
+            label={"Username"}
+            title={"user_name"}
+            value={currentUserName}
+            onChange={(e) => {
+              setCurrentUserName(e.target.value);
+
+              // temporary, will need to do multiselect later
+              setInviteeNames([e.target.value]);
+            }}
+          />
+        </DialogContent>
+        <DialogActions>
+          <Button variant="contained" onClick={onSubmit}>
+            Invite
+          </Button>
+        </DialogActions>
+      </Dialog>
+      <Tooltip title="Assign users to this channel">
+        <IconButton
+          sx={{ maxHeight: "24px", borderRadius: "4px" }}
+          edge="end"
+          onClick={() => setIsDialogOpen(true)}
+        >
+          <PersonAddIcon />
+        </IconButton>
+      </Tooltip>
+    </>
+  );
+}

--- a/app/frontend/src/components/InviteToTeamButton.tsx
+++ b/app/frontend/src/components/InviteToTeamButton.tsx
@@ -13,6 +13,7 @@ import GroupAddIcon from "@mui/icons-material/GroupAdd";
 import { useState } from "react";
 
 import wretch from "wretch";
+import { toast } from "react-toastify";
 
 interface IInviteToTeamButtonProps {
   teamId: number;
@@ -33,9 +34,11 @@ export default function InviteToTeamButton(props: IInviteToTeamButtonProps) {
         .res(() => {
           setIsDialogOpen(false);
           props.refetchData();
+          toast.success("User(s) have been added successfully.");
         })
         .catch((error) => {
           console.error(error);
+          toast.error("An error has occurred.");
         });
     }
   };

--- a/app/frontend/src/components/InviteToTeamButton.tsx
+++ b/app/frontend/src/components/InviteToTeamButton.tsx
@@ -1,0 +1,80 @@
+import {
+  Button,
+  Dialog,
+  DialogActions,
+  DialogContent,
+  DialogTitle,
+  IconButton,
+  TextField,
+  Tooltip,
+} from "@mui/material";
+import GroupAddIcon from "@mui/icons-material/GroupAdd";
+
+import { useState } from "react";
+
+import wretch from "wretch";
+
+interface IInviteToTeamButtonProps {
+  teamId: number;
+  teamName: string;
+  refetchData: () => void;
+}
+
+export default function InviteToTeamButton(props: IInviteToTeamButtonProps) {
+  const [isDialogOpen, setIsDialogOpen] = useState<boolean>(false);
+  const [inviteeNames, setInviteeNames] = useState<string[]>([]);
+  const [currentUserName, setCurrentUserName] = useState<string>("");
+
+  const onSubmit = () => {
+    if (inviteeNames.length > 0) {
+      wretch(`http://localhost:3001/api/add/addtoteam`)
+        .auth(`Bearer ${localStorage.getItem("jwt-token")}`)
+        .post({ team_id: props.teamId, users_to_add: inviteeNames })
+        .res(() => {
+          setIsDialogOpen(false);
+          props.refetchData();
+        })
+        .catch((error) => {
+          console.error(error);
+        });
+    }
+  };
+  return (
+    <>
+      <Dialog open={isDialogOpen} onClose={() => setIsDialogOpen(false)}>
+        <DialogTitle>Add users to {props.teamName}</DialogTitle>
+        <DialogContent
+          sx={{
+            minHeight: "100px",
+            alignContent: "center",
+          }}
+        >
+          <TextField
+            label={"Username"}
+            title={"user_name"}
+            value={currentUserName}
+            onChange={(e) => {
+              setCurrentUserName(e.target.value);
+
+              // temporary, will need to do multiselect later
+              setInviteeNames([e.target.value]);
+            }}
+          />
+        </DialogContent>
+        <DialogActions>
+          <Button variant="contained" onClick={onSubmit}>
+            Invite
+          </Button>
+        </DialogActions>
+      </Dialog>{" "}
+      <Tooltip title="Add users to the team">
+        <IconButton
+          sx={{ height: "52px", width: "47%" }}
+          onClick={() => setIsDialogOpen(true)}
+        >
+          <GroupAddIcon></GroupAddIcon>
+        </IconButton>
+      </Tooltip>
+    </>
+  );
+}

--- a/app/frontend/src/components/RegisterForm.tsx
+++ b/app/frontend/src/components/RegisterForm.tsx
@@ -10,6 +10,7 @@ import {
 } from "@mui/material";
 import { useState } from "react";
 import { useNavigate } from "react-router-dom";
+import { toast } from "react-toastify";
 
 export interface IRegisterFormProps {}
 
@@ -38,9 +39,8 @@ export default function RegisterForm(props: IRegisterFormProps) {
       });
       const data = await response.json();
       if (response.ok) {
-        console.log("Registeration successful");
-        alert("Registration successful!");
-        navigate("/login");
+        toast.success("Account registered successfully!");
+        navigate("/");
       } else {
         throw new Error(data.error || "Registration failed");
       }

--- a/app/frontend/src/components/SideBar.tsx
+++ b/app/frontend/src/components/SideBar.tsx
@@ -1,24 +1,19 @@
 import {
-  Drawer,
   Grid2 as Grid,
   List,
   ListItem,
   IconButton,
   Box,
-  ListItemButton,
-  ListItemText,
   Tooltip,
   Divider,
   Typography,
   SwipeableDrawer,
-  Button,
 } from "@mui/material";
 import PersonIcon from "@mui/icons-material/Person";
 import ChatIcon from "@mui/icons-material/Chat";
 import GroupsIcon from "@mui/icons-material/Groups";
 import SettingsIcon from "@mui/icons-material/Settings";
 import LogoutIcon from "@mui/icons-material/Logout";
-import AddIcon from "@mui/icons-material/Add";
 import GroupAddIcon from "@mui/icons-material/GroupAdd";
 
 import { IChannelModel, ITeamModel } from "../models/models";
@@ -29,6 +24,7 @@ import "../styles/SideBar.css";
 import { useState } from "react";
 import CreateTeamButton from "./CreateTeamButton";
 import ChannelListItem from "./ChannelListItem";
+import CreateChannelButton from "./CreateChannelButton";
 
 interface ISideBarProps {
   teams: ITeamModel[];
@@ -153,8 +149,9 @@ export default function SideBar(props: ISideBarProps) {
               justifyItems="center"
               alignContent={"center"}
             >
-              <CreateTeamButton refetchData={props.refetchData} />
-
+              {props.isUserAdmin && (
+                <CreateTeamButton refetchData={props.refetchData} />
+              )}
               <Box height={"8px"} />
 
               <IconButton disableFocusRipple>
@@ -214,25 +211,27 @@ export default function SideBar(props: ISideBarProps) {
           </List>
 
           <Divider variant="middle" />
-          <Grid
-            className={"team-actions"}
-            container
-            p="8px"
-            justifyContent="space-between"
-            width={"100%"}
-            spacing={1}
-          >
-            <Tooltip title="Create a channel">
-              <IconButton sx={{ height: "52px", width: "47%" }}>
-                <AddIcon></AddIcon>
-              </IconButton>
-            </Tooltip>
-            <Tooltip title="Add users to the team">
-              <IconButton sx={{ height: "52px", width: "47%" }}>
-                <GroupAddIcon></GroupAddIcon>
-              </IconButton>
-            </Tooltip>
-          </Grid>
+          {props.selectedTeam && props.isUserAdmin && (
+            <Grid
+              className={"team-actions"}
+              container
+              p="8px"
+              justifyContent="space-between"
+              width={"100%"}
+              spacing={1}
+            >
+              <CreateChannelButton
+                teamId={props.selectedTeam?.team_id ?? -1}
+                refetchData={props.refetchData}
+              />
+
+              <Tooltip title="Add users to the team">
+                <IconButton sx={{ height: "52px", width: "47%" }}>
+                  <GroupAddIcon></GroupAddIcon>
+                </IconButton>
+              </Tooltip>
+            </Grid>
+          )}
         </Grid>
       </Grid>
     </SwipeableDrawer>

--- a/app/frontend/src/components/SideBar.tsx
+++ b/app/frontend/src/components/SideBar.tsx
@@ -118,7 +118,9 @@ export default function SideBar(props: ISideBarProps) {
           <List
             sx={{
               maxWidth: "100%",
-              height: "calc(100vh - 360px)",
+              height: props.isUserAdmin
+                ? "calc(100vh - 360px)"
+                : "calc(100vh - 275px)",
               overflowY: "scroll",
               scrollbarWidth: "none", // firefox
               "&::-webkit-scrollbar": {
@@ -145,15 +147,16 @@ export default function SideBar(props: ISideBarProps) {
             <Divider variant="middle" />
             <Box
               width={"100%"}
-              height={"204px"}
+              height={props.isUserAdmin ? "204px" : "120px"}
               justifyItems="center"
               alignContent={"center"}
             >
               {props.isUserAdmin && (
-                <CreateTeamButton refetchData={props.refetchData} />
+                <>
+                  <CreateTeamButton refetchData={props.refetchData} />
+                  <Box height={"8px"} />
+                </>
               )}
-              <Box height={"8px"} />
-
               <IconButton disableFocusRipple>
                 <SettingsIcon></SettingsIcon>
               </IconButton>
@@ -189,7 +192,9 @@ export default function SideBar(props: ISideBarProps) {
           <List
             sx={{
               maxWidth: "100%",
-              height: "calc(100vh - 160px)",
+              height: props.isUserAdmin
+                ? "calc(100vh - 160px)"
+                : "calc(100vh - 120px)",
               overflowY: "scroll",
               scrollbarWidth: "none", // firefox
               "&::-webkit-scrollbar": {

--- a/app/frontend/src/components/SideBar.tsx
+++ b/app/frontend/src/components/SideBar.tsx
@@ -16,10 +16,14 @@ import PersonIcon from "@mui/icons-material/Person";
 import ChatIcon from "@mui/icons-material/Chat";
 import GroupsIcon from "@mui/icons-material/Groups";
 import SettingsIcon from "@mui/icons-material/Settings";
+import LogoutIcon from "@mui/icons-material/Logout";
 import { IChannelModel, ITeamModel } from "../models/models";
+
+import Cookies from "js-cookie";
 
 import "../styles/SideBar.css";
 import { useState } from "react";
+import CreateTeamButton from "./CreateTeamButton";
 
 interface ISideBarProps {
   teams: ITeamModel[];
@@ -33,6 +37,8 @@ interface ISideBarProps {
   drawerVariant: "permanent" | "persistent" | "temporary";
   drawerOpen: boolean;
   handleDrawerToggle: () => void;
+
+  refetchData: () => void;
 }
 
 export default function SideBar(props: ISideBarProps) {
@@ -53,6 +59,12 @@ export default function SideBar(props: ISideBarProps) {
 
       setState(open);
     };
+
+  const logOut = () => {
+    Cookies.remove("isLoggedIn");
+    localStorage.removeItem("jwt-token");
+    window.location.href = "http://localhost:5173"; // modify this later probably
+  };
 
   return (
     <SwipeableDrawer
@@ -104,7 +116,7 @@ export default function SideBar(props: ISideBarProps) {
           <List
             sx={{
               maxWidth: "100%",
-              height: "calc(100vh - 230px)",
+              height: "calc(100vh - 360px)",
               overflowY: "scroll",
               scrollbarWidth: "none", // firefox
               "&::-webkit-scrollbar": {
@@ -129,10 +141,21 @@ export default function SideBar(props: ISideBarProps) {
           </List>
           <Grid>
             <Divider variant="middle" />
-            <Box width={"100%"} height={"68px"} alignContent={"center"}>
+            <Box width={"100%"} height={"204px"} alignContent={"center"}>
+              <CreateTeamButton refetchData={props.refetchData} />
+
+              <Box height={"8px"} />
+
               <IconButton disableFocusRipple>
                 <SettingsIcon></SettingsIcon>
               </IconButton>
+              <Box height={"8px"} />
+
+              <Tooltip placement="right" title="Log out">
+                <IconButton onClick={logOut}>
+                  <LogoutIcon />
+                </IconButton>
+              </Tooltip>
             </Box>
           </Grid>
         </Grid>

--- a/app/frontend/src/components/SideBar.tsx
+++ b/app/frontend/src/components/SideBar.tsx
@@ -206,6 +206,7 @@ export default function SideBar(props: ISideBarProps) {
               (channel: IChannelModel) =>
                 channel.team_id === props.selectedTeam?.team_id && (
                   <ChannelListItem
+                    refetchData={props.refetchData}
                     key={channel.id}
                     isUserAdmin={props.isUserAdmin}
                     channel={channel}

--- a/app/frontend/src/components/SideBar.tsx
+++ b/app/frontend/src/components/SideBar.tsx
@@ -11,12 +11,16 @@ import {
   Divider,
   Typography,
   SwipeableDrawer,
+  Button,
 } from "@mui/material";
 import PersonIcon from "@mui/icons-material/Person";
 import ChatIcon from "@mui/icons-material/Chat";
 import GroupsIcon from "@mui/icons-material/Groups";
 import SettingsIcon from "@mui/icons-material/Settings";
 import LogoutIcon from "@mui/icons-material/Logout";
+import AddIcon from "@mui/icons-material/Add";
+import GroupAddIcon from "@mui/icons-material/GroupAdd";
+
 import { IChannelModel, ITeamModel } from "../models/models";
 
 import Cookies from "js-cookie";
@@ -24,6 +28,7 @@ import Cookies from "js-cookie";
 import "../styles/SideBar.css";
 import { useState } from "react";
 import CreateTeamButton from "./CreateTeamButton";
+import ChannelListItem from "./ChannelListItem";
 
 interface ISideBarProps {
   teams: ITeamModel[];
@@ -39,6 +44,7 @@ interface ISideBarProps {
   handleDrawerToggle: () => void;
 
   refetchData: () => void;
+  isUserAdmin: boolean;
 }
 
 export default function SideBar(props: ISideBarProps) {
@@ -141,7 +147,12 @@ export default function SideBar(props: ISideBarProps) {
           </List>
           <Grid>
             <Divider variant="middle" />
-            <Box width={"100%"} height={"204px"} alignContent={"center"}>
+            <Box
+              width={"100%"}
+              height={"204px"}
+              justifyItems="center"
+              alignContent={"center"}
+            >
               <CreateTeamButton refetchData={props.refetchData} />
 
               <Box height={"8px"} />
@@ -167,6 +178,7 @@ export default function SideBar(props: ISideBarProps) {
           container
           direction={"column"}
           overflow={"hidden"}
+          justifyContent={"space-between"}
         >
           <Box
             className={"selected-team-title"}
@@ -177,23 +189,50 @@ export default function SideBar(props: ISideBarProps) {
           </Box>
           <Divider variant="middle" />
 
-          <List sx={{ width: "100%" }}>
+          <List
+            sx={{
+              maxWidth: "100%",
+              height: "calc(100vh - 160px)",
+              overflowY: "scroll",
+              scrollbarWidth: "none", // firefox
+              "&::-webkit-scrollbar": {
+                display: "none", // chrome, safari, opera
+              },
+            }}
+          >
             {props.channels.map(
               (channel: IChannelModel) =>
                 channel.team_id === props.selectedTeam?.team_id && (
-                  <ListItemButton
-                    className="channel-item"
+                  <ChannelListItem
                     key={channel.id}
-                    onClick={() => props.setSelectedChannel(channel)}
-                  >
-                    <ListItemText
-                      primary={channel.channel_name}
-                      slotProps={{ primary: { noWrap: true } }}
-                    />
-                  </ListItemButton>
+                    isUserAdmin={props.isUserAdmin}
+                    channel={channel}
+                    setSelectedChannel={props.setSelectedChannel}
+                  />
                 ),
             )}
           </List>
+
+          <Divider variant="middle" />
+          <Grid
+            className={"team-actions"}
+            container
+            p="8px"
+            justifyContent="space-between"
+            width={"100%"}
+            spacing={1}
+          >
+            <Tooltip title="Create a channel">
+              <IconButton sx={{ height: "52px", width: "47%" }}>
+                <AddIcon></AddIcon>
+              </IconButton>
+            </Tooltip>
+            <Tooltip title="Add users to the team">
+              <IconButton sx={{ height: "52px", width: "47%" }}>
+                <GroupAddIcon></GroupAddIcon>
+              </IconButton>
+            </Tooltip>
+          </Grid>
         </Grid>
       </Grid>
     </SwipeableDrawer>

--- a/app/frontend/src/components/SideBar.tsx
+++ b/app/frontend/src/components/SideBar.tsx
@@ -14,7 +14,6 @@ import ChatIcon from "@mui/icons-material/Chat";
 import GroupsIcon from "@mui/icons-material/Groups";
 import SettingsIcon from "@mui/icons-material/Settings";
 import LogoutIcon from "@mui/icons-material/Logout";
-import GroupAddIcon from "@mui/icons-material/GroupAdd";
 
 import { IChannelModel, ITeamModel } from "../models/models";
 
@@ -25,6 +24,7 @@ import { useState } from "react";
 import CreateTeamButton from "./CreateTeamButton";
 import ChannelListItem from "./ChannelListItem";
 import CreateChannelButton from "./CreateChannelButton";
+import InviteToTeamButton from "./InviteToTeamButton";
 
 interface ISideBarProps {
   teams: ITeamModel[];
@@ -230,11 +230,11 @@ export default function SideBar(props: ISideBarProps) {
                 refetchData={props.refetchData}
               />
 
-              <Tooltip title="Add users to the team">
-                <IconButton sx={{ height: "52px", width: "47%" }}>
-                  <GroupAddIcon></GroupAddIcon>
-                </IconButton>
-              </Tooltip>
+              <InviteToTeamButton
+                teamId={props.selectedTeam?.team_id ?? -1}
+                teamName={props.selectedTeam?.team_name ?? "this team"}
+                refetchData={props.refetchData}
+              />
             </Grid>
           )}
         </Grid>

--- a/app/frontend/src/styles/SideBar.css
+++ b/app/frontend/src/styles/SideBar.css
@@ -22,9 +22,17 @@
   }
 
   .MuiListItemButton-root.channel-item {
+    justify-content: space-between;
     background-color: #11111140;
     margin: 8px;
     border-radius: 4px;
+  }
+
+  .team-actions {
+    .MuiIconButton-root {
+      border-radius: 8px !important;
+      background-color: #11111140;
+    }
   }
 }
 


### PR DESCRIPTION
# Description

Add controls for creating teams and channels, as well as adding users to channels and teams. Controls are for admins only.
Connected controls to the backend (minor modifications of the backend were done to make them work)
Added confirmation toasts for register, create team, create channel, add to team, add to channel.

## New package
[react-toastify](https://www.npmjs.com/package/react-toastify)
Toast messages! woohoo!

## Screenshots

### Admin view
![image](https://github.com/user-attachments/assets/e5a3be2e-1b0d-46a8-acd7-e002c65aca2e)

### Hovering over a channel as an admin
![image](https://github.com/user-attachments/assets/444ababf-e1b5-40ee-96cb-07938dbfba84)

### Dialog example
![image](https://github.com/user-attachments/assets/be65d61b-b809-4a1c-a8f0-4bb3449132da)

### Toast success example
![image](https://github.com/user-attachments/assets/1e966c62-2bfb-4f09-a57b-557c8ea3faec)

### Toast error example
![image](https://github.com/user-attachments/assets/dee3a692-fdfe-4fdd-b9b4-229b46bf785a)

### Mobile view
![image](https://github.com/user-attachments/assets/5483ab92-56a5-4c87-acba-0a09eb91267b)
