### PR TITLE
Fix launch script #38

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,29 @@
+{
+  "version": "0.2.0",
+  "compounds": [
+    {
+      "name": "Local Development",
+      "configurations": ["local-backend", "local-frontend"]
+    }
+  ],
+  "configurations": [
+    {
+      "name": "local-backend",
+      "type": "coreclr",
+      "request": "launch",
+      "preLaunchTask": "build-backend",
+      "program": "${workspaceFolder}/app/backend/bin/Debug/net9.0/ChatHaven.dll",
+      "cwd": "${workspaceFolder}/app/backend",
+      "console": "integratedTerminal"
+    },
+    {
+      "name": "local-frontend",
+      "type": "node",
+      "request": "launch",
+      "cwd": "${workspaceFolder}/app/frontend",
+      "runtimeExecutable": "npm",
+      "runtimeArgs": ["run", "dev"],
+      "console": "integratedTerminal"
+    }
+  ]
+}

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -1,0 +1,16 @@
+{
+	"version": "2.0.0",
+	"tasks": [
+	  {
+		"label": "build-backend",
+		"command": "dotnet",
+		"type": "process",
+		"args": ["build"],
+		"problemMatcher": "$msCompile",
+		"group": "build",
+		"options": {
+		  "cwd": "${workspaceFolder}/app/backend"
+		}
+	  }
+	]
+  }

--- a/app/.husky/pre-commit
+++ b/app/.husky/pre-commit
@@ -1,0 +1,1 @@
+npx lint-staged


### PR DESCRIPTION
## Description
I broke the launch script by removing launch.json and tasks.json from .vscode, and vscode doesn't recognize this folde runless it's in the repository's root. This breaking change happened in #120 

This reverts it by moving .vscode to the root, and re-adds the launch scripts.

respectfully ms. TA don't you dare remove points for this. we literally need it this way to run.