### PR TITLE
API changes for Private Channels Implementation

### DIFF
--- a/app/backend/Controllers/ChannelCreationRequest.cs
+++ b/app/backend/Controllers/ChannelCreationRequest.cs
@@ -2,4 +2,5 @@ public class ChannelCreationRequest
 {
     public required string channel_name { get; set; }
     public required int team_id { get; set; }
+    public required string visibility { get; set; }
 }

--- a/app/backend/Controllers/ChatController.cs
+++ b/app/backend/Controllers/ChatController.cs
@@ -23,6 +23,21 @@ public class ChatController : Controller
     [Authorize]
     public async Task<IActionResult> RetrieveChannelMessages([FromQuery] int channelId) // Read from query
     {
+
+        // Get user information
+        var username = User.FindFirst(ClaimTypes.NameIdentifier)?.Value;
+        var user = await _context.Users.FirstOrDefaultAsync(u => u.username == username);
+
+        if (user == null)
+            return BadRequest(new { error = "User not found" });
+
+        //Check if user is part of that channel
+        var isChannelMember = await _context.ChannelMemberships.FirstOrDefaultAsync(cm => cm.channel_id == channelId && cm.user_id == user.user_id);
+        if (isChannelMember == null)
+        {
+            return BadRequest(new { error = "User is not a member of this channel" });
+        }
+
         Channel channel = await _context.Channels.FirstOrDefaultAsync(c => c.id == channelId); // Find channel
         if (channel == null) return BadRequest(new { error = "Channel not found." });
 

--- a/app/backend/Controllers/CreateController.cs
+++ b/app/backend/Controllers/CreateController.cs
@@ -91,7 +91,7 @@ public class CreateController : Controller
             if (team == null) // Is there a team with the given team_id? If not, return error.
                 return BadRequest(new { error = "Team not found" });
 
-            var channel = new Channel { channel_name = req.channel_name, team_id = team.team_id };
+            var channel = new Channel { channel_name = req.channel_name, team_id = team.team_id, visibility = req.visibility };
             Channel channelFound = _context.Channels.FirstOrDefault(c => c.team_id == team.team_id && c.channel_name == req.channel_name);
             if (channelFound == null)
             { // Is there a channel with the given name? If not, add channel
@@ -167,8 +167,8 @@ public class CreateController : Controller
 
         List<string> users = await _context.Users
             .Where(user => !_context.DirectMessageChannels
-                .Any(channel => 
-                    (channel.user_id1 == userId && channel.user_id2 == user.user_id) 
+                .Any(channel =>
+                    (channel.user_id1 == userId && channel.user_id2 == user.user_id)
                     || (channel.user_id2 == userId && channel.user_id1 == user.user_id)))
             .Select(g => g.username)
             .ToListAsync();

--- a/app/backend/Controllers/HomeController.cs
+++ b/app/backend/Controllers/HomeController.cs
@@ -52,7 +52,7 @@ public class HomeController : Controller
                     .Select(t => t.team_name)
                     .FirstOrDefault(),
                 channels = _context.Channels
-                    .Where(c => c.team_id == tm.team_id && _context.ChannelMemberships.Any(cm => cm.channel_id == c.id && cm.user_id == user.user_id))
+                    .Where(c => c.team_id == tm.team_id /*&& _context.ChannelMemberships.Any(cm => cm.channel_id == c.id && cm.user_id == user.user_id)*/) // Removed when implementing private channels
                     .Select(c => new
                     {
                         c.team_id,

--- a/app/backend/Models/ChannelModel.cs
+++ b/app/backend/Models/ChannelModel.cs
@@ -12,5 +12,8 @@ namespace ChatHaven.Models
         public required string channel_name { get; set; }
         [Required]
         public required int team_id { get; set; }
+
+        [Required]
+        public required string visibility { get; set; }
     }
 }


### PR DESCRIPTION
This adds a new required parameter when creating a team, visibility, which can be set to public or private. (Though this may not even be necessary 🤔). Also it now fetches all channels in a team, but only successfully retrieves the messages if the user is actually in that channel. 
I expect this will trigger some frontend code telling the user they are not in that channel and giving them the chance to request to join.
We also will have to delay the websockets joining on the front end, only until we confirm the user is in the channel. (Or we could add a new variable for each channel in the initial fetch to signal whether a user actually is a member of the channel).