### PR TITLE
Private channel invites #218

### DIFF
--- a/app/backend/Controllers/AddController.cs
+++ b/app/backend/Controllers/AddController.cs
@@ -39,11 +39,12 @@ public class AddController : ControllerBase
     [Authorize]
     public async Task<IActionResult> SendAllChannelUsers([FromBody] int Id)
     { // For removing from channels
-        IQueryable<User> users = _context.Users.Where(u => _context.ChannelMemberships.Where(c => c.channel_id == Id).Select(m => m.user_id).Contains(u.user_id));
-        List<string> usernames = await users.Select(g => g.username).ToListAsync();
-        List<int> ids = await users.Select(g => g.user_id).ToListAsync();
-        List<string> activities = await users.Select(g => g.Activity).ToListAsync();
-        return Ok(new { usernames, ids, activities });
+        IQueryable<User> users = _context.Users
+        .Where(u => _context.ChannelMemberships.Where(c => c.channel_id == Id).Select(m => m.user_id).Contains(u.user_id));
+
+        var response = await users.Select(u => new { u.user_id, u.username, u.Activity }).ToListAsync();
+    
+        return Ok(new { users = response });
     }
 
     [HttpPost("sendallteamusers")]
@@ -51,10 +52,8 @@ public class AddController : ControllerBase
     public async Task<IActionResult> SendAllTeamUsers([FromBody] int Id)
     { // For removing from teams
         IQueryable<User> users = _context.Users.Where(u => _context.TeamMemberships.Where(t => t.team_id == Id).Select(m => m.user_id).Contains(u.user_id));
-        List<string> usernames = await users.Select(g => g.username).ToListAsync();
-        List<int> ids = await users.Select(g => g.user_id).ToListAsync();
-        List<string> activities = await users.Select(g => g.Activity).ToListAsync();
-        return Ok(new { usernames, ids, activities });
+        var response = await users.Select(u => new { u.user_id, u.username, activity = u.Activity }).ToListAsync();
+        return Ok(new { users = response });
     }
 
     [HttpPost("addtoteam")]

--- a/app/backend/Controllers/RequestController.cs
+++ b/app/backend/Controllers/RequestController.cs
@@ -29,13 +29,13 @@ public class RequestController : Controller
         if (user == null) // Is there a user with the given username? If not, return error
             return BadRequest(new { error = "User not found" });
 
-        var requests = await _context.Requests.Where(r => r.channel_owner_id == user.user_id).ToListAsync();
+        var requests = await _context.Requests.Where(r => r.recipient_id == user.user_id).ToListAsync();
         return Ok(requests);
     }
 
-    [HttpPost("create-request")]
+    [HttpPost("join")]
     [Authorize]
-    public async Task<IActionResult> CreateRequest([FromBody] Request req)
+    public async Task<IActionResult> CreateJoinRequest([FromBody] Request req)
     {
         var username = User.FindFirst(ClaimTypes.NameIdentifier)?.Value;
 
@@ -46,6 +46,11 @@ public class RequestController : Controller
 
         if (!ModelState.IsValid)
             return BadRequest(new { error = "Invalid input", details = ModelState });
+
+        if (req.request_type != "join")
+        {
+            return BadRequest(new { error = "Invalid request type." });
+        }
 
         if (_context.Requests.Any(obj => obj.requester_id == req.requester_id && obj.channel_id == req.channel_id))
         {
@@ -72,10 +77,77 @@ public class RequestController : Controller
             {
                 requester_id = user.user_id,
                 requester_name = user.username,
-                channel_owner_id = channel.owner_id.Value,
+                recipient_id = channel.owner_id.Value,
                 channel_id = channel.id,
                 channel_name = channel.channel_name,
                 team_name = team.team_name,
+                request_type = "join",
+                created_at = DateTime.UtcNow
+            };
+            _context.Requests.Add(request);
+            await _context.SaveChangesAsync();
+
+            await transaction.CommitAsync();
+            return StatusCode(201, new { message = "Request created successfully", requestId = request.request_id });
+        }
+        catch (Exception ex)
+        {
+            await transaction.RollbackAsync();
+            return StatusCode(500, new { error = "Failed to create request", details = ex.Message });
+        }
+
+    }
+
+    [HttpPost("invite")]
+    [Authorize]
+    public async Task<IActionResult> CreateInviteRequest([FromBody] Request req)
+    {
+
+        var username = User.FindFirst(ClaimTypes.NameIdentifier)?.Value;
+
+        var user = await _context.Users.FirstOrDefaultAsync(u => u.username == username);
+
+        if (user == null) // Is there a user with the given username? If not, return error
+            return BadRequest(new { error = "User not found" });
+
+        if (!ModelState.IsValid)
+            return BadRequest(new { error = "Invalid input", details = ModelState });
+
+        if (req.request_type != "invite")
+        {
+            return BadRequest(new { error = "Invalid request type." });
+        }
+
+        if (_context.Requests.Any(obj => obj.recipient_id == req.recipient_id && obj.channel_id == req.channel_id))
+        {
+            return BadRequest(new { error = "The request already exists." });
+        }
+
+        using var transaction = await _context.Database.BeginTransactionAsync();
+        try
+        {
+            var channel = await _context.Channels.FirstOrDefaultAsync(c => c.id == req.channel_id);
+            if (channel == null) // Is there a channel with the given channel_id? If not, return error
+                return BadRequest(new { error = "Channel not found" });
+
+            if (channel.owner_id == null)
+            {
+                return BadRequest(new { error = "Channel owner not found" });
+            }
+
+            var team = await _context.Teams.FirstOrDefaultAsync(t => t.team_id == channel.team_id);
+            if (team == null) // Is there a team with the given team_id? If not, return error
+                return BadRequest(new { error = "Team not found" });
+
+            var request = new Request
+            {
+                requester_id = user.user_id,
+                requester_name = user.username,
+                recipient_id = req.recipient_id,
+                channel_id = channel.id,
+                channel_name = channel.channel_name,
+                team_name = team.team_name,
+                request_type = "invite",
                 created_at = DateTime.UtcNow
             };
             _context.Requests.Add(request);
@@ -110,59 +182,121 @@ public class RequestController : Controller
         if (request == null) // Is there a request with the given request_id? If not, return error
             return BadRequest(new { error = "Request not found" });
 
-        if (request.channel_owner_id != user.user_id) // Is the user the owner of the channel?
-            return Unauthorized(new { error = "You are not the owner of the channel" });
-
-        using var transaction = await _context.Database.BeginTransactionAsync();
-        try
+        if (request.request_type == "join")
         {
-            if (req.accept) // request accepted
+            if (request.recipient_id != user.user_id) // Is the user the owner of the channel?
+                return Unauthorized(new { error = "You are not the owner of the channel" });
+
+            using var transaction = await _context.Database.BeginTransactionAsync();
+            try
             {
-                var channel = await _context.Channels.FirstOrDefaultAsync(obj => obj.id == request.channel_id);
-                if (channel == null)  // No channel with the requested id within the team? Return error
+                if (req.accept) // request accepted
                 {
-                    return BadRequest(new { error = "Channel not found" });
-                }
-
-                var requester = await _context.Users.FirstOrDefaultAsync(obj => obj.user_id == request.requester_id);
-                if (requester == null) // the requester is not found
-                {
-                    return BadRequest(new { error = "Requester not found" });
-                }
-
-                var channelMembership = await _context.ChannelMemberships.FirstOrDefaultAsync(obj => obj.user_id == request.requester_id && obj.channel_id == channel.id);
-                if (channelMembership != null) // Already a member of the channel?
-                {
-                    return BadRequest(new { error = "User is already a member of the channel" });
-                }
-                else
-                {
-                    channelMembership = new ChannelMembership
+                    var channel = await _context.Channels.FirstOrDefaultAsync(obj => obj.id == request.channel_id);
+                    if (channel == null)  // No channel with the requested id within the team? Return error
                     {
-                        user_id = requester.user_id,
-                        channel_id = channel.id,
-                        created_at = DateTime.UtcNow
-                    };
-                    _context.ChannelMemberships.Add(channelMembership); // Add user to channel
+                        return BadRequest(new { error = "Channel not found" });
+                    }
+
+                    var requester = await _context.Users.FirstOrDefaultAsync(obj => obj.user_id == request.requester_id);
+                    if (requester == null) // the requester is not found
+                    {
+                        return BadRequest(new { error = "Requester not found" });
+                    }
+
+                    var channelMembership = await _context.ChannelMemberships.FirstOrDefaultAsync(obj => obj.user_id == request.requester_id && obj.channel_id == channel.id);
+                    if (channelMembership != null) // Already a member of the channel?
+                    {
+                        return BadRequest(new { error = "User is already a member of the channel" });
+                    }
+                    else
+                    {
+                        channelMembership = new ChannelMembership
+                        {
+                            user_id = requester.user_id,
+                            channel_id = channel.id,
+                            created_at = DateTime.UtcNow
+                        };
+                        _context.ChannelMemberships.Add(channelMembership); // Add user to channel
+                    }
                 }
+
+                _context.Requests.Remove(request); // delete the request, no matter the answer
+                await _context.SaveChangesAsync();
+                await transaction.CommitAsync();
+                return Ok(new { message = "Request " + (req.accept ? "Accepted" : "Declined") + " successfully" });
+
+
+            }
+            catch (Exception ex)
+            {
+                await transaction.RollbackAsync();
+                return StatusCode(500, new
+                {
+                    error = "Failed to answer request",
+                    details = ex.Message
+                });
+            }
+        }
+        else // it's an invite
+        {
+            if (request.recipient_id != user.user_id) // Is the current user the recipient of the invite?
+                return Unauthorized(new { error = "You are not the correct recipient of this invite." });
+
+            using var transaction = await _context.Database.BeginTransactionAsync();
+            try
+            {
+                if (req.accept) // request accepted
+                {
+                    var channel = await _context.Channels.FirstOrDefaultAsync(obj => obj.id == request.channel_id);
+                    if (channel == null)  // No channel with the requested id within the team? Return error
+                    {
+                        return BadRequest(new { error = "Channel not found" });
+                    }
+
+                    var recipient = await _context.Users.FirstOrDefaultAsync(obj => obj.user_id == request.recipient_id);
+                    if (recipient == null) // the recipient is not found
+                    {
+                        return BadRequest(new { error = "Recipient not found" });
+                    }
+
+                    var channelMembership = await _context.ChannelMemberships.FirstOrDefaultAsync(obj => obj.user_id == request.requester_id && obj.channel_id == channel.id);
+                    if (channelMembership != null) // Already a member of the channel?
+                    {
+                        return BadRequest(new { error = "User is already a member of the channel" });
+                    }
+                    else
+                    {
+                        channelMembership = new ChannelMembership
+                        {
+                            user_id = recipient.user_id,
+                            channel_id = channel.id,
+                            created_at = DateTime.UtcNow
+                        };
+                        _context.ChannelMemberships.Add(channelMembership); // Add user to channel
+                    }
+                }
+
+                _context.Requests.Remove(request); // delete the request, no matter the answer
+                await _context.SaveChangesAsync();
+                await transaction.CommitAsync();
+                return Ok(new { message = "Request " + (req.accept ? "Accepted" : "Declined") + " successfully" });
+
+
+            }
+            catch (Exception ex)
+            {
+                await transaction.RollbackAsync();
+                return StatusCode(500, new
+                {
+                    error = "Failed to answer request",
+                    details = ex.Message
+                });
             }
 
-            _context.Requests.Remove(request); // delete the request, no matter the answer
-            await _context.SaveChangesAsync();
-            await transaction.CommitAsync();
-            return Ok(new { message = "Request " + (req.accept ? "Accepted" : "Declined") + " successfully" });
+        }
 
 
-        }
-        catch (Exception ex)
-        {
-            await transaction.RollbackAsync();
-            return StatusCode(500, new
-            {
-                error = "Failed to answer request",
-                details = ex.Message
-            });
-        }
 
     }
 

--- a/app/backend/DTOs/MassInviteCreationRequest.cs
+++ b/app/backend/DTOs/MassInviteCreationRequest.cs
@@ -1,0 +1,10 @@
+public class MassInviteCreationRequest
+{
+    public required int team_id { get; set; }
+    public required int channel_id { get; set; }
+    public required int requester_id { get; set; }
+    public required string requester_name { get; set; }
+    public required string channel_name { get; set; }
+    public required string team_name { get; set; }
+    public required List<string> users_to_invite { get; set; }
+}

--- a/app/backend/Models/RequestModel.cs
+++ b/app/backend/Models/RequestModel.cs
@@ -12,7 +12,7 @@ namespace ChatHaven.Models
         public required int requester_id { get; set; }
 
         [Required]
-        public required int channel_owner_id { get; set; }
+        public required int recipient_id { get; set; }
 
         [Required]
         public required int channel_id { get; set; }
@@ -25,6 +25,9 @@ namespace ChatHaven.Models
 
         [Required]
         public required string team_name { get; set; }
+
+        [Required]
+        public required string request_type { get; set; }
 
         [Required]
         public required DateTime created_at { get; set; }

--- a/app/frontend/src/components/Buttons/InviteToChannelButton.tsx
+++ b/app/frontend/src/components/Buttons/InviteToChannelButton.tsx
@@ -113,7 +113,7 @@ export default function InviteToChannelButton(
         .post({
           team_id: props.teamId,
           channel_id: props.channel.id,
-          // users_to_add: inviteeNames, // replaced by invite requests as of sprint 4 march 26th
+          users_to_add: [], // replaced by invite requests as of sprint 4 march 26th
           users_to_delete: deletionList.map((u) => u.username),
         })
         .res(() => {
@@ -146,7 +146,7 @@ export default function InviteToChannelButton(
         });
     }
     refetchData();
-    setIsDialogOpen(false);
+    quit();
   };
 
   const quit = () => {

--- a/app/frontend/src/components/ChannelUserListHover.tsx
+++ b/app/frontend/src/components/ChannelUserListHover.tsx
@@ -42,22 +42,11 @@ export default function TeamUserListHover(
           props.channel.is_public ? props.channel.team_id : props.channel.id,
         ),
       )
-      .json(
-        (data: {
-          usernames: string[];
-          ids: number[];
-          activities: string[];
-        }) => {
-          const { usernames, ids, activities } = data;
-          setUsers(
-            usernames.map((name, i) => ({
-              username: name,
-              user_id: ids[i],
-              activity: activities[i],
-            })),
-          );
-        },
-      )
+      .json((data) => {
+        const users: { user_id: number; username: string; activity: string }[] =
+          data.users;
+        setUsers(users);
+      })
       .catch((error) => {
         console.error(error);
         toast.error("An error has occurred.");

--- a/app/frontend/src/components/Chat/ChannelChatComponent.tsx
+++ b/app/frontend/src/components/Chat/ChannelChatComponent.tsx
@@ -277,7 +277,7 @@ export default function ChannelChatComponent(props: ChannelChatComponentProps) {
               <CircularProgress />
             </Box>
           ) : displayRequestOptions ? (
-            <RequestCreationPrompt />
+            <RequestCreationPrompt fetchMessages={fetchMessages} />
           ) : (
             messages.map((message: IChannelMessageModel, index: number) => (
               <Box

--- a/app/frontend/src/components/Chat/RequestCreationPrompt.tsx
+++ b/app/frontend/src/components/Chat/RequestCreationPrompt.tsx
@@ -5,6 +5,7 @@ import { API_URL } from "../../utils/FetchUtils";
 import { toast } from "react-toastify";
 import { useUserStore } from "../../stores/UserStore";
 import { useApplicationStore } from "../../stores/ApplicationStore";
+import { IRequestModel } from "../../models/models";
 
 export default function RequestCreationPrompt() {
   const currentUser = useUserStore((state) => state.user);
@@ -13,17 +14,29 @@ export default function RequestCreationPrompt() {
 
   const requestAccess = () => {
     // request object to be sent to the backend
-    const request = {
+
+    if (
+      !currentUser ||
+      !selectedChannel ||
+      !selectedTeam ||
+      !selectedChannel.owner_id
+    )
+      return;
+
+    const request: IRequestModel = {
+      request_id: 0, // doesn't actually matter, this is determined in the backend but needs to be defined to respect IRequestModel
+
       requester_id: currentUser?.user_id,
       requester_name: currentUser?.username,
       channel_id: selectedChannel?.id,
       channel_name: selectedChannel?.channel_name,
       team_name: selectedTeam?.team_name,
-      channel_owner_id: selectedChannel?.owner_id,
+      recipient_id: selectedChannel?.owner_id,
+      request_type: "join",
       created_at: new Date().toISOString(),
     };
 
-    wretch(`${API_URL}/api/request/create-request`)
+    wretch(`${API_URL}/api/request/join`)
       .auth(`Bearer ${localStorage.getItem("jwt-token")}`)
       .post(request)
       .res(() => {

--- a/app/frontend/src/components/Chat/RequestCreationPrompt.tsx
+++ b/app/frontend/src/components/Chat/RequestCreationPrompt.tsx
@@ -1,4 +1,4 @@
-import { Box, Typography, Button } from "@mui/material";
+import { Box, Typography, Button, IconButton } from "@mui/material";
 import wretch from "wretch";
 import SendIcon from "@mui/icons-material/Send";
 import { API_URL } from "../../utils/FetchUtils";
@@ -6,12 +6,64 @@ import { toast } from "react-toastify";
 import { useUserStore } from "../../stores/UserStore";
 import { useApplicationStore } from "../../stores/ApplicationStore";
 import { IRequestModel } from "../../models/models";
+import { useEffect, useState } from "react";
 
-export default function RequestCreationPrompt() {
+import CheckIcon from "@mui/icons-material/Check";
+import CloseIcon from "@mui/icons-material/Close";
+
+interface RequestCreationPromptProps {
+  fetchMessages: () => Promise<void>;
+}
+
+export default function RequestCreationPrompt(
+  props: RequestCreationPromptProps,
+) {
   const currentUser = useUserStore((state) => state.user);
   const selectedChannel = useApplicationStore((state) => state.selectedChannel);
   const selectedTeam = useApplicationStore((state) => state.selectedTeam);
 
+  const [requestExists, setRequestExists] = useState<boolean>(true);
+  const [existingRequestId, setExistingRequestId] = useState<number>(-1);
+  const [existingRequestType, setExistingRequestType] = useState<string>("");
+  const [isFetchingRequestStatus, setIsFetchingRequestStatus] =
+    useState<boolean>(false);
+
+  const checkIfRequestExists = () => {
+    setIsFetchingRequestStatus(true);
+    wretch(`${API_URL}/api/request/exists?channel_id=${selectedChannel?.id}`)
+      .auth(`Bearer ${localStorage.getItem("jwt-token")}`)
+      .get()
+      .json((data) => {
+        setRequestExists(data.exists);
+        if (data.exists) {
+          setExistingRequestType(data.type);
+          setExistingRequestId(data.request_id);
+        }
+        setIsFetchingRequestStatus(false);
+      });
+  };
+
+  const answerInviteRequest = (accept: boolean) => {
+    wretch(`${API_URL}/api/request/answer-request`)
+      .auth(`Bearer ${localStorage.getItem("jwt-token")}`)
+      .post({ request_id: existingRequestId, accept: accept })
+      .res((response) => {
+        if (response.ok) {
+          toast.success(
+            `Request ${accept ? "accepted" : "declined"} successfully.`,
+          );
+          props.fetchMessages();
+        }
+      })
+      .catch((error) => {
+        console.error(error);
+        toast.error("An error has occurred.");
+      });
+  };
+
+  useEffect(() => {
+    checkIfRequestExists();
+  }, []);
   const requestAccess = () => {
     // request object to be sent to the backend
 
@@ -48,19 +100,53 @@ export default function RequestCreationPrompt() {
       });
   };
 
+  const secondaryText = requestExists
+    ? existingRequestType === "join"
+      ? "A request to join has already been sent to the channel owner."
+      : "The channel owner has invited you to join this channel."
+    : "Would you like to request access to this channel?";
+
   return (
     <Box sx={{ textAlign: "center", mt: 2 }}>
       <Typography variant="h6" mb={2}>
         You do not have permission to access this channel.
       </Typography>
-      <Typography variant="body1" mb={2}>
-        Would you like to request access to this channel?
-      </Typography>
 
-      <Button variant={"contained"} sx={{ p: 1.2 }} onClick={requestAccess}>
-        Request access
-        <SendIcon sx={{ ml: 2 }} />
-      </Button>
+      {!isFetchingRequestStatus && (
+        <Box>
+          <Typography variant="body1" mb={2}>
+            {secondaryText}
+          </Typography>
+
+          {!requestExists && (
+            <Button
+              variant={"contained"}
+              sx={{ p: 1.2 }}
+              onClick={requestAccess}
+            >
+              Request access
+              <SendIcon sx={{ ml: 2 }} />
+            </Button>
+          )}
+
+          {existingRequestType == "invite" && (
+            <Box>
+              <IconButton
+                color="success"
+                onClick={() => answerInviteRequest(true)}
+              >
+                <CheckIcon />
+              </IconButton>
+              <IconButton
+                color="error"
+                onClick={() => answerInviteRequest(false)}
+              >
+                <CloseIcon />
+              </IconButton>
+            </Box>
+          )}
+        </Box>
+      )}
     </Box>
   );
 }

--- a/app/frontend/src/components/Dashboard/DashboardRequestsTabContent.tsx
+++ b/app/frontend/src/components/Dashboard/DashboardRequestsTabContent.tsx
@@ -1,6 +1,6 @@
 import { Box, Grid2 as Grid } from "@mui/material";
 import { useEffect, useState } from "react";
-import { IChannelRequestModel, IUserModel } from "../../models/models";
+import { IRequestModel, IUserModel } from "../../models/models";
 import RequestsList from "../Requests/RequestsList";
 import UserList from "../UserList";
 import wretch from "wretch";
@@ -8,7 +8,7 @@ import { API_URL } from "../../utils/FetchUtils";
 import { toast } from "react-toastify";
 
 export default function DashboardRequestsTabContent() {
-  const [requests, setRequests] = useState<IChannelRequestModel[]>([]);
+  const [requests, setRequests] = useState<IRequestModel[]>([]);
   const [users, setUsers] = useState<IUserModel[]>([]);
 
   useEffect(() => {

--- a/app/frontend/src/components/Dashboard/DashboardRequestsTabContent.tsx
+++ b/app/frontend/src/components/Dashboard/DashboardRequestsTabContent.tsx
@@ -10,22 +10,21 @@ import { toast } from "react-toastify";
 export default function DashboardRequestsTabContent() {
   const [requests, setRequests] = useState<IRequestModel[]>([]);
   const [users, setUsers] = useState<IUserModel[]>([]);
-
-  useEffect(() => {
-    refetchRequests();
-  }, []);
+  const [isFetching, setIsFetching] = useState(false);
 
   const refetchRequests = () => {
+    setIsFetching(true);
     wretch(`${API_URL}/api/request/requests`)
       .auth(`Bearer ${localStorage.getItem("jwt-token")}`)
       .get()
       .json((data) => {
-        console.log(data);
         setRequests(data);
+        setIsFetching(false);
       })
       .catch((error) => {
         console.error(error);
         toast.error("An error has occurred.");
+        setIsFetching(false);
       });
   };
 
@@ -43,6 +42,7 @@ export default function DashboardRequestsTabContent() {
   };
 
   useEffect(() => {
+    refetchRequests();
     fetchUsers();
   }, []);
 
@@ -61,6 +61,7 @@ export default function DashboardRequestsTabContent() {
             requests={requests}
             setRequests={setRequests}
             refetchRequests={refetchRequests}
+            isFetching={isFetching}
           />
         </Grid>
         <Grid size={{ xs: 12, sm: 5, md: 4 }}>

--- a/app/frontend/src/components/Requests/RequestsList.tsx
+++ b/app/frontend/src/components/Requests/RequestsList.tsx
@@ -1,5 +1,5 @@
 import { Box, IconButton, List, Typography } from "@mui/material";
-import { IChannelRequestModel } from "../../models/models";
+import { IRequestModel } from "../../models/models";
 import RequestsListItem from "./RequestsListItem";
 import "../../styles/Requests.css";
 import wretch from "wretch";
@@ -9,8 +9,8 @@ import { API_URL } from "../../utils/FetchUtils";
 import { toast } from "react-toastify";
 
 interface RequestsListProps {
-  requests: IChannelRequestModel[];
-  setRequests: (requests: IChannelRequestModel[]) => void;
+  requests: IRequestModel[];
+  setRequests: (requests: IRequestModel[]) => void;
   refetchRequests?: () => void;
 }
 

--- a/app/frontend/src/components/Requests/RequestsList.tsx
+++ b/app/frontend/src/components/Requests/RequestsList.tsx
@@ -1,4 +1,12 @@
-import { Box, IconButton, List, Typography } from "@mui/material";
+import {
+  Box,
+  CircularProgress,
+  IconButton,
+  List,
+  ListItem,
+  ListSubheader,
+  Typography,
+} from "@mui/material";
 import { IRequestModel } from "../../models/models";
 import RequestsListItem from "./RequestsListItem";
 import "../../styles/Requests.css";
@@ -12,6 +20,7 @@ interface RequestsListProps {
   requests: IRequestModel[];
   setRequests: (requests: IRequestModel[]) => void;
   refetchRequests?: () => void;
+  isFetching?: boolean;
 }
 
 export default function RequestsList(props: RequestsListProps) {
@@ -37,39 +46,86 @@ export default function RequestsList(props: RequestsListProps) {
       });
   };
 
+  const joinRequests = props.requests.filter(
+    (request) => request.request_type == "join",
+  );
+  const inviteRequests = props.requests.filter(
+    (request) => request.request_type == "invite",
+  );
+
   return (
     <Box maxHeight="88vh" overflow={"hidden"} mt={1}>
-      {props.requests.length > 0 && (
-        <List
-          className="request-list"
-          sx={{
-            display: "flex",
-            flexDirection: "column",
-            gap: 1,
-            maxHeight: "88vh",
-            overflowY: "scroll",
-            "&::-webkit-scrollbar": {
-              width: "8px",
-            },
-            "&::-webkit-scrollbar-thumb": {
-              backgroundColor: "#899483",
-              borderRadius: "4px",
-            },
-            "&::-webkit-scrollbar-thumb:hover": {
-              backgroundColor: "#5F6959",
-            },
-          }}
-          disablePadding
-        >
-          {props.requests.map((request) => (
-            <RequestsListItem
-              handleAction={handleAction}
-              request={request}
-              key={request.request_id}
-            />
-          ))}
-        </List>
+      {props.isFetching && (
+        <Box display="flex" justifyContent="center" alignItems="center" mt={2}>
+          <CircularProgress />
+        </Box>
       )}
+      <List
+        className="request-list"
+        sx={{
+          display: "flex",
+          flexDirection: "column",
+          gap: 1,
+          maxHeight: "88vh",
+          overflowY: "scroll",
+          "&::-webkit-scrollbar": {
+            width: "8px",
+          },
+          "&::-webkit-scrollbar-thumb": {
+            backgroundColor: "#899483",
+            borderRadius: "4px",
+          },
+          "&::-webkit-scrollbar-thumb:hover": {
+            backgroundColor: "#5F6959",
+          },
+        }}
+        disablePadding
+      >
+        {joinRequests.length > 0 && (
+          <ListItem>
+            <List
+              sx={{
+                width: "100%",
+                gap: 1,
+                display: "flex",
+                flexDirection: "column",
+              }}
+              disablePadding
+            >
+              <ListSubheader>Join Requests</ListSubheader>
+              {joinRequests.map((request) => (
+                <RequestsListItem
+                  handleAction={handleAction}
+                  request={request}
+                  key={request.request_id}
+                />
+              ))}
+            </List>
+          </ListItem>
+        )}
+        {inviteRequests.length > 0 && (
+          <ListItem>
+            <List
+              sx={{
+                width: "100%",
+                gap: 1,
+                display: "flex",
+                flexDirection: "column",
+              }}
+              disablePadding
+            >
+              <ListSubheader>Invite Requests</ListSubheader>
+              {inviteRequests.map((request) => (
+                <RequestsListItem
+                  handleAction={handleAction}
+                  request={request}
+                  key={request.request_id}
+                />
+              ))}
+            </List>
+          </ListItem>
+        )}
+      </List>
 
       {props.requests.length === 0 && (
         <Box>

--- a/app/frontend/src/components/Requests/RequestsListItem.tsx
+++ b/app/frontend/src/components/Requests/RequestsListItem.tsx
@@ -7,14 +7,14 @@ import {
   Box,
   IconButton,
 } from "@mui/material";
-import { IChannelRequestModel } from "../../models/models";
+import { IRequestModel } from "../../models/models";
 import { stringAvatar } from "../../utils/AvatarUtils";
 
 import CheckIcon from "@mui/icons-material/Check";
 import CloseIcon from "@mui/icons-material/Close";
 
 interface RequestsListItemProps {
-  request: IChannelRequestModel;
+  request: IRequestModel;
   handleAction: (request_id: number, isAccept: boolean) => void;
 }
 

--- a/app/frontend/src/components/Requests/RequestsListItem.tsx
+++ b/app/frontend/src/components/Requests/RequestsListItem.tsx
@@ -27,6 +27,15 @@ export default function RequestsListItem(props: RequestsListItemProps) {
     props.handleAction(props.request.request_id, false);
   };
 
+  const primaryText =
+    props.request.requester_name +
+    (props.request.request_type == "join"
+      ? " wants to join "
+      : " is inviting you to join ") +
+    '"' +
+    props.request.channel_name +
+    '"';
+
   return (
     <ListItem
       className="request-list-item"
@@ -36,11 +45,7 @@ export default function RequestsListItem(props: RequestsListItemProps) {
         <Grid container size={"grow"} columnSpacing={2}>
           <Avatar {...stringAvatar(props.request.requester_name)} />
           <Grid size="grow" alignContent={"center"}>
-            <Typography display="inline">
-              {props.request.requester_name +
-                " wants to join " +
-                props.request.channel_name}
-            </Typography>
+            <Typography display="inline">{primaryText}</Typography>
 
             {props.request.team_name && (
               <Typography display="inline" color="secondary">

--- a/app/frontend/src/components/Sidebar/ChannelListItem.tsx
+++ b/app/frontend/src/components/Sidebar/ChannelListItem.tsx
@@ -116,9 +116,7 @@ export default function ChannelListItem(props: IChannelListItemProps) {
         <InviteToChannelButton
           displayButton={areChannelActionsVisible}
           teamId={props.channel.team_id}
-          channelId={props.channel.id}
-          channelName={props.channel.channel_name}
-          channelPub={props.channel.is_public}
+          channel={props.channel}
         />
       )}
     </ListItemButton>

--- a/app/frontend/src/components/TeamUserListHover.tsx
+++ b/app/frontend/src/components/TeamUserListHover.tsx
@@ -33,26 +33,11 @@ export default function TeamUserListHover(
       .auth(`Bearer ${localStorage.getItem("jwt-token")}`)
       .headers({ "Content-Type": "application/json" })
       .post(JSON.stringify(props.team.team_id))
-      .json(
-        (data: {
-          usernames: string[];
-          ids: number[];
-          activities: string[];
-        }) => {
-          const [usernames, ids, activities] = [
-            data.usernames,
-            data.ids,
-            data.activities,
-          ];
-          setUsers(
-            usernames.map((name, i) => ({
-              username: name,
-              user_id: ids[i],
-              activity: activities[i],
-            })),
-          );
-        },
-      )
+      .json((data) => {
+        const users: { user_id: number; username: string; activity: string }[] =
+          data.users;
+        setUsers(users);
+      })
       .catch((error) => {
         console.error(error);
         toast.error("An error has occurred.");

--- a/app/frontend/src/components/UserList.tsx
+++ b/app/frontend/src/components/UserList.tsx
@@ -8,7 +8,7 @@ import {
   TextField,
 } from "@mui/material";
 import { useEffect, useRef, useState } from "react";
-import { IUserModel, UserActivity } from "../models/models";
+import { IChannelModel, IUserModel, UserActivity } from "../models/models";
 import UserListItem from "./UserListItem";
 import { Property } from "csstype";
 
@@ -18,6 +18,7 @@ interface UserListProps {
   update?: (users: IUserModel[]) => void;
   fullWidth?: boolean;
   height?: number;
+  channel?: IChannelModel;
 }
 
 export default function UserList(props: UserListProps) {
@@ -171,6 +172,7 @@ export default function UserList(props: UserListProps) {
               isHover={props.isHover ?? false}
               toBeDeleted={false}
               deletion={deletion}
+              channelOwnerId={props.channel?.owner_id}
             />
           ))}
       </List>

--- a/app/frontend/src/components/UserListItem.tsx
+++ b/app/frontend/src/components/UserListItem.tsx
@@ -28,6 +28,7 @@ interface IUserListItemProps {
   isHover: boolean;
   toBeDeleted: boolean;
   deletion: (user: IUserModel) => void;
+  channelOwnerId?: number;
 }
 
 export default function UserListItem(props: IUserListItemProps) {
@@ -39,36 +40,33 @@ export default function UserListItem(props: IUserListItemProps) {
   );
 
   const userId = props.user.user_id;
-    const [lastSeen, setLastSeen] = useState<string | null>(null);
-    useEffect(() => {
-      const fetchLastSeen = async () => {
-        if (!userId) return;
-        try {
-          const response = await fetch('/api/home/last-seen', {
-            method: 'POST',
-            headers: {
-              'Content-Type': 'application/json',
-              'Authorization': `Bearer ${localStorage.getItem('token')}`
-            },
-            body: JSON.stringify({ UserId: userId })
-          });
-          if (!response.ok) {
-            throw new Error('Failed to fetch last seen data');
-          }
-          const data = await response.json();
-          console.log("FETCHING TIMESTAMP:")
-          console.log(data);
-          setLastSeen(data.last_seen);
-        } catch (error) {
-          console.error('Error fetching last seen:', error);
+  const [lastSeen, setLastSeen] = useState<string | null>(null);
+  useEffect(() => {
+    const fetchLastSeen = async () => {
+      if (!userId) return;
+      try {
+        const response = await fetch("/api/home/last-seen", {
+          method: "POST",
+          headers: {
+            "Content-Type": "application/json",
+            Authorization: `Bearer ${localStorage.getItem("token")}`,
+          },
+          body: JSON.stringify({ UserId: userId }),
+        });
+        if (!response.ok) {
+          throw new Error("Failed to fetch last seen data");
         }
-      };
-  
-      fetchLastSeen();
-    }, [userId]);
-  
-    
-  
+        const data = await response.json();
+        console.log("FETCHING TIMESTAMP:");
+        console.log(data);
+        setLastSeen(data.last_seen);
+      } catch (error) {
+        console.error("Error fetching last seen:", error);
+      }
+    };
+
+    fetchLastSeen();
+  }, [userId]);
 
   const [isCreateDMConfirmationVisible, setIsCreateDMConfirmationVisible] =
     useState<boolean>();
@@ -134,7 +132,7 @@ export default function UserListItem(props: IUserListItemProps) {
 
   // check if the user is the owner of the selected channel, if so, don't show the delete button under manage users
   const isUserTheSelectedChannelOwner =
-    applicationState.selectedChannel?.owner_id == props.user.user_id;
+    props.channelOwnerId == props.user.user_id;
 
   return (
     <ListItem
@@ -157,15 +155,20 @@ export default function UserListItem(props: IUserListItemProps) {
         sx={{ justifyContent: "space-between", alignItems: "center" }}
       >
         <Grid size="auto">
-        <Tooltip
-        title={props.user.activity === "Offline" ? `Last seen ${formatLastSeen(lastSeen)}` : props.user.activity}placement="left">
-        <Box>
-          <ActivityBadge activity={props.user.activity as UserActivity}>
-            <Avatar {...stringAvatar(props.user.username)} />
-          </ActivityBadge>
-        </Box>
-      </Tooltip>
-
+          <Tooltip
+            title={
+              props.user.activity === "Offline"
+                ? `Last seen ${formatLastSeen(lastSeen)}`
+                : props.user.activity
+            }
+            placement="left"
+          >
+            <Box>
+              <ActivityBadge activity={props.user.activity as UserActivity}>
+                <Avatar {...stringAvatar(props.user.username)} />
+              </ActivityBadge>
+            </Box>
+          </Tooltip>
         </Grid>
         <Grid size="grow">
           <ListItemText

--- a/app/frontend/src/models/models.ts
+++ b/app/frontend/src/models/models.ts
@@ -58,13 +58,14 @@ export type IDMChannelModel = {
   otherUser: IUserModel;
 };
 
-export type IChannelRequestModel = {
+export type IRequestModel = {
   request_id: number;
   requester_id: number;
   requester_name: string;
-  channel_owner_id: number;
+  recipient_id: number;
   channel_id: number;
   channel_name: string;
   team_name: string;
+  request_type: "join" | "invite"; 
   created_at?: string;
 };

--- a/app/frontend/tests/InviteToChannelButton.test.tsx
+++ b/app/frontend/tests/InviteToChannelButton.test.tsx
@@ -24,9 +24,13 @@ describe("InviteToChannelButton", () => {
 
   const defaultProps = {
     teamId: 1,
-    channelId: 1,
-    channelName: "testchannel",
-    channelPub: true,
+    channel: {
+      team_id: 1,
+      id: 1,
+      channel_name: "testchannel",
+      is_public: true,
+      owner_id: 1,
+    },
     displayButton: true,
   };
 


### PR DESCRIPTION
# Description
- Makes adding users to private channels invitation request based.
- Channel owners will need to first send requests to the users they want to invite, and those invitations must be accepted before the user can access the channel.
- The dashboard request list now features two sections - join requests and invite requests.
- When trying to access a private channel that the user does not have access to, they can encounter 1 of 3 scenarios:
    1. No existing request - the user is presented with a "request to join" button
    2. Existing join request - the user is presented with a message letting them know that the owner has received their request
    3. Existing invite request - the user is presented with the option to accept or decline the invitation.

## Screenshots
### Dashboard

![image](https://github.com/user-attachments/assets/502808fd-694a-4072-886d-5188213eb872)

### Scenario 1
![image](https://github.com/user-attachments/assets/9b8d5627-0de9-4253-bee1-a465e6cd3fdc)

### Scenario 2
![image](https://github.com/user-attachments/assets/3637ebeb-8b8b-4f0a-b200-c1005e501e3e)

### Scenario 3
![image](https://github.com/user-attachments/assets/241e1bae-fafe-41b2-a38f-b8c3f4724ecb)


Resolves #218
