### PR TITLE
Mobile view rework #220

### DIFF
--- a/app/backend/Controllers/RequestController.cs
+++ b/app/backend/Controllers/RequestController.cs
@@ -274,7 +274,7 @@ public class RequestController : Controller
 
         if (successCount > 0)
         {
-            return StatusCode(201, new { message = successCount + " user" + (successCount > 1 ? "s" : "") + "successfully invited to the channel" });
+            return StatusCode(201, new { message = successCount + " user" + (successCount > 1 ? "s" : "") + " successfully invited to the channel" });
 
         }
         else

--- a/app/frontend/src/App.tsx
+++ b/app/frontend/src/App.tsx
@@ -39,15 +39,6 @@ function App() {
           },
         },
       },
-      MuiTooltip: {
-        defaultProps: {
-          slotProps: {
-            popper: {
-              disablePortal: true, // fix for tooltips staying rendered on fast scroll because of fixed framerate
-            },
-          },
-        },
-      },
     },
   });
 

--- a/app/frontend/src/components/Chat/ChannelChatComponent.tsx
+++ b/app/frontend/src/components/Chat/ChannelChatComponent.tsx
@@ -26,6 +26,7 @@ import ChatMessage from "./ChatMessage";
 import RequestCreationPrompt from "./RequestCreationPrompt";
 import { useUserStore } from "../../stores/UserStore";
 import { activitySubmit } from "../../utils/ActivityUtils";
+import { isMobile } from "../../utils/BrowserUtils";
 
 interface ChannelChatComponentProps {
   channelId: number;
@@ -314,6 +315,9 @@ export default function ChannelChatComponent(props: ChannelChatComponentProps) {
     }
   };
 
+  const isUserMobile = isMobile();
+  const containerHeightReduction = (chatbarRef.current ? 115 + chatbarHeight : 0) + (isUserMobile ? 60 : 0);
+
   return (
     <Box
       style={{
@@ -328,7 +332,7 @@ export default function ChannelChatComponent(props: ChannelChatComponentProps) {
           sx={{
             maxHeight:
               "calc(100vh - " +
-              (chatbarRef.current ? 115 + chatbarHeight : 0) +
+              containerHeightReduction +
               "px)",
             overflowY: loading ? "hidden" : "auto",
             "&::-webkit-scrollbar": {
@@ -419,7 +423,10 @@ export default function ChannelChatComponent(props: ChannelChatComponentProps) {
           )}
         </Box>
       </Box>
-      {!displayRequestOptions && <Grid container spacing={1}>
+      {!displayRequestOptions && <Grid container sx={{width: isUserMobile ? "93.5%" : "100%"}} spacing={1}
+        position={isUserMobile ? "fixed" : "relative"}
+        bottom={isUserMobile ? "16px" : "inherit"}
+      >
         {props.isUserAdmin && (
           <Grid className={"delete-messages-button-wrapper"}>
             <DeleteChannelMessagesButton

--- a/app/frontend/src/components/Chat/ChatArea.tsx
+++ b/app/frontend/src/components/Chat/ChatArea.tsx
@@ -1,4 +1,12 @@
-import { useMediaQuery, useTheme } from "@mui/material";
+import {
+  AppBar,
+  Grid2 as Grid,
+  IconButton,
+  Toolbar,
+  Typography,
+  useMediaQuery,
+  useTheme,
+} from "@mui/material";
 import {
   useApplicationStore,
   ViewModes,
@@ -10,11 +18,14 @@ import ChatAreaDMHeader from "./ChatAreaDMHeader.tsx";
 import ChatTeamsChannelHeader from "./ChatTeamsChannelHeader.tsx";
 import DMChatComponent from "./DMChatComponent.tsx";
 import Dashboard from "../Dashboard/Dashboard.tsx";
+import MenuIcon from "@mui/icons-material/Menu";
 
 interface ChatAreaProps {
   isDirectMessage?: boolean;
   isChannel?: boolean;
   isUserAdmin: boolean;
+
+  toggleSidebar: () => void;
 }
 
 export default function ChatArea(props: ChatAreaProps) {
@@ -40,6 +51,32 @@ export default function ChatArea(props: ChatAreaProps) {
         height: isMobile ? "96.6vh" : "auto",
       }}
     >
+      {isMobile && (
+        <Grid
+          container
+          className={"channel-title-bar"}
+          sx={{
+            display: "flex",
+            alignItems: "center",
+            justifyContent: "start",
+            mb: "8px",
+          }}
+        >
+          <IconButton
+            size="large"
+            edge="start"
+            color="inherit"
+            aria-label="menu"
+            onClick={() => {
+              console.log("what the fuck", props.toggleSidebar);
+              props.toggleSidebar();
+            }}
+          >
+            <MenuIcon />
+          </IconButton>
+          <Typography variant="h6">ChatHaven</Typography>
+        </Grid>
+      )}
       {applicationState.viewMode === ViewModes.Dashboard && <Dashboard />}
 
       {applicationState.viewMode === ViewModes.Team && (

--- a/app/frontend/src/components/Chat/ChatArea.tsx
+++ b/app/frontend/src/components/Chat/ChatArea.tsx
@@ -18,7 +18,7 @@ import ChatAreaDMHeader from "./ChatAreaDMHeader.tsx";
 import ChatTeamsChannelHeader from "./ChatTeamsChannelHeader.tsx";
 import DMChatComponent from "./DMChatComponent.tsx";
 import Dashboard from "../Dashboard/Dashboard.tsx";
-import MenuIcon from "@mui/icons-material/Menu";
+import MobileToolbar from "../MobileToolbar.tsx";
 
 interface ChatAreaProps {
   isDirectMessage?: boolean;
@@ -51,32 +51,7 @@ export default function ChatArea(props: ChatAreaProps) {
         height: isMobile ? "96.6vh" : "auto",
       }}
     >
-      {isMobile && (
-        <Grid
-          container
-          className={"channel-title-bar"}
-          sx={{
-            display: "flex",
-            alignItems: "center",
-            justifyContent: "start",
-            mb: "8px",
-          }}
-        >
-          <IconButton
-            size="large"
-            edge="start"
-            color="inherit"
-            aria-label="menu"
-            onClick={() => {
-              console.log("what the fuck", props.toggleSidebar);
-              props.toggleSidebar();
-            }}
-          >
-            <MenuIcon />
-          </IconButton>
-          <Typography variant="h6">ChatHaven</Typography>
-        </Grid>
-      )}
+      {isMobile && <MobileToolbar toggleSidebar={props.toggleSidebar} />}
       {applicationState.viewMode === ViewModes.Dashboard && <Dashboard />}
 
       {applicationState.viewMode === ViewModes.Team && (

--- a/app/frontend/src/components/Chat/ChatAreaDMHeader.tsx
+++ b/app/frontend/src/components/Chat/ChatAreaDMHeader.tsx
@@ -40,8 +40,6 @@ export default function ChatAreaDMHeader(props: ChatAreaDMHeaderProps) {
           throw new Error("Failed to fetch last seen data");
         }
         const data = await response.json();
-        console.log("FETCHING TIMESTAMP:");
-        console.log(data);
         setLastSeen(data.last_seen);
       } catch (error) {
         console.error("Error fetching last seen:", error);

--- a/app/frontend/src/components/Chat/DMChatComponent.tsx
+++ b/app/frontend/src/components/Chat/DMChatComponent.tsx
@@ -18,6 +18,7 @@ import { API_URL } from "../../utils/FetchUtils";
 import ChatMessage from "./ChatMessage";
 import { useApplicationStore } from "../../stores/ApplicationStore";
 import { activitySubmit } from "../../utils/ActivityUtils";
+import { isMobile } from "../../utils/BrowserUtils";
 
 interface DMChatComponentProps {
   dmId: number;
@@ -164,6 +165,10 @@ export default function DMChatComponent(props: DMChatComponentProps) {
     setReplyingTo(null);
   };
 
+  const isUserMobile = isMobile();
+  const containerHeightReduction =
+    (chatbarRef.current ? 115 + chatbarHeight : 0) + (isUserMobile ? 60 : 0);
+
   return (
     <Box
       style={{
@@ -176,10 +181,7 @@ export default function DMChatComponent(props: DMChatComponentProps) {
         <Box
           className={"text-content"}
           sx={{
-            maxHeight:
-              "calc(100vh - " +
-              (chatbarRef.current ? 115 + chatbarHeight : 0) +
-              "px)",
+            maxHeight: "calc(100vh - " + containerHeightReduction + "px)",
             overflowY: loading ? "hidden" : "auto",
             "&::-webkit-scrollbar": {
               width: "8px",
@@ -271,43 +273,51 @@ export default function DMChatComponent(props: DMChatComponentProps) {
         </Grid>
       )}
 
-      <Grid
-        container
-        spacing={1}
-        alignItems="center"
-        className={"chat-bar-wrapper"}
-      >
-        <Grid sx={{ flexGrow: 1 }}>
-          <TextField
-            disabled={loading}
-            sx={{
-              minHeight: "52px",
-              border: "none",
-              textWrap: "wrap",
-              width: "100%",
-              borderRadius: replyingTo !== null ? "0 0 4px 4px" : "4px",
-            }}
-            ref={chatbarRef}
-            fullWidth
-            multiline
-            maxRows={5}
-            autoComplete="off"
-            onChange={(event) => setMessage(event.target.value)}
-            onKeyDown={(keyEvent) => {
-              if (keyEvent.key === "Enter" && !keyEvent.shiftKey) {
-                keyEvent.preventDefault();
-                sendMessage();
+      <Grid container spacing={1}>
+        <Grid
+          position={isUserMobile ? "fixed" : "relative"}
+          maxWidth={isUserMobile ? "93.5%" : "100%"} // if only i were a good frontend dev right
+          bottom={isUserMobile ? "16px" : "inherit"}
+          container
+          spacing={1}
+          alignItems="center"
+          className={"chat-bar-wrapper"}
+          size={"grow"}
+        >
+          <Grid sx={{ flexGrow: 1 }}>
+            <TextField
+              disabled={loading}
+              sx={{
+                minHeight: "52px",
+                border: "none",
+                textWrap: "wrap",
+                width: "100%",
+                borderRadius: replyingTo !== null ? "0 0 4px 4px" : "4px",
+              }}
+              ref={chatbarRef}
+              fullWidth
+              multiline
+              maxRows={5}
+              autoComplete="off"
+              onChange={(event) => setMessage(event.target.value)}
+              onKeyDown={(keyEvent) => {
+                if (keyEvent.key === "Enter" && !keyEvent.shiftKey) {
+                  keyEvent.preventDefault();
+                  sendMessage();
+                }
+              }}
+              value={message}
+              placeholder={
+                replyingTo !== null
+                  ? "Reply to message..."
+                  : "Type a message..."
               }
-            }}
-            value={message}
-            placeholder={
-              replyingTo !== null ? "Reply to message..." : "Type a message..."
-            }
-          />
+            />
+          </Grid>
+          <IconButton onClick={sendMessage}>
+            <SendIcon />
+          </IconButton>
         </Grid>
-        <IconButton onClick={sendMessage}>
-          <SendIcon />
-        </IconButton>
       </Grid>
     </Box>
   );

--- a/app/frontend/src/components/Dashboard/DashboardRequestsTabContent.tsx
+++ b/app/frontend/src/components/Dashboard/DashboardRequestsTabContent.tsx
@@ -75,7 +75,12 @@ export default function DashboardRequestsTabContent() {
           style={{ overflowY: "hidden" }}
           sx={{ maxHeight: isUserMobile ? "42vh" : "auto" }}
         >
-          <UserList fullWidth isHover users={users} height={85} />
+          <UserList
+            fullWidth
+            isHover
+            users={users}
+            height={isUserMobile ? 42 : 85}
+          />
         </Grid>
       </Grid>
     </Box>

--- a/app/frontend/src/components/Dashboard/DashboardRequestsTabContent.tsx
+++ b/app/frontend/src/components/Dashboard/DashboardRequestsTabContent.tsx
@@ -6,6 +6,7 @@ import UserList from "../UserList";
 import wretch from "wretch";
 import { API_URL } from "../../utils/FetchUtils";
 import { toast } from "react-toastify";
+import { isMobile } from "../../utils/BrowserUtils";
 
 export default function DashboardRequestsTabContent() {
   const [requests, setRequests] = useState<IRequestModel[]>([]);
@@ -47,6 +48,7 @@ export default function DashboardRequestsTabContent() {
   }, []);
 
   //TODO handle mobile view
+  const isUserMobile = isMobile();
   return (
     <Box
       style={{
@@ -56,7 +58,11 @@ export default function DashboardRequestsTabContent() {
       }}
     >
       <Grid container mt={"12px"}>
-        <Grid size={{ xs: 12, sm: 7, md: 8 }}>
+        <Grid
+          size={{ xs: 12, sm: 7, md: 8 }}
+          style={{ overflowY: "hidden" }}
+          sx={{ maxHeight: isUserMobile ? "42vh" : "auto" }}
+        >
           <RequestsList
             requests={requests}
             setRequests={setRequests}
@@ -64,7 +70,11 @@ export default function DashboardRequestsTabContent() {
             isFetching={isFetching}
           />
         </Grid>
-        <Grid size={{ xs: 12, sm: 5, md: 4 }}>
+        <Grid
+          size={{ xs: 12, sm: 5, md: 4 }}
+          style={{ overflowY: "hidden" }}
+          sx={{ maxHeight: isUserMobile ? "42vh" : "auto" }}
+        >
           <UserList fullWidth isHover users={users} height={85} />
         </Grid>
       </Grid>

--- a/app/frontend/src/components/MobileToolbar.tsx
+++ b/app/frontend/src/components/MobileToolbar.tsx
@@ -1,0 +1,35 @@
+import { Grid2 as Grid, IconButton, Typography } from "@mui/material";
+import MenuIcon from "@mui/icons-material/Menu";
+
+interface MobileToolbarProps {
+  toggleSidebar: () => void;
+}
+
+export default function MobileToolbar(props: MobileToolbarProps) {
+  return (
+    <Grid
+      container
+      className={"channel-title-bar"}
+      sx={{
+        display: "flex",
+        alignItems: "center",
+        justifyContent: "start",
+        mb: "8px",
+      }}
+    >
+      <IconButton
+        size="large"
+        edge="start"
+        color="inherit"
+        aria-label="menu"
+        disableFocusRipple
+        onClick={() => {
+          props.toggleSidebar();
+        }}
+      >
+        <MenuIcon />
+      </IconButton>
+      <Typography variant="h6">ChatHaven</Typography>
+    </Grid>
+  );
+}

--- a/app/frontend/src/components/Requests/RequestsList.tsx
+++ b/app/frontend/src/components/Requests/RequestsList.tsx
@@ -69,7 +69,7 @@ export default function RequestsList(props: RequestsListProps) {
           display: "flex",
           flexDirection: "column",
           gap: 1,
-          maxHeight: isUserMobile? "42vh" : "88vh",
+          maxHeight: isUserMobile? "40vh" : "88vh",
           overflowY: "scroll",
           "&::-webkit-scrollbar": {
             width: "8px",

--- a/app/frontend/src/components/Requests/RequestsList.tsx
+++ b/app/frontend/src/components/Requests/RequestsList.tsx
@@ -15,6 +15,7 @@ import wretch from "wretch";
 import RefreshIcon from "@mui/icons-material/Refresh";
 import { API_URL } from "../../utils/FetchUtils";
 import { toast } from "react-toastify";
+import { isMobile } from "../../utils/BrowserUtils";
 
 interface RequestsListProps {
   requests: IRequestModel[];
@@ -53,6 +54,8 @@ export default function RequestsList(props: RequestsListProps) {
     (request) => request.request_type == "invite",
   );
 
+  const isUserMobile = isMobile();
+
   return (
     <Box maxHeight="88vh" overflow={"hidden"} mt={1}>
       {props.isFetching && (
@@ -66,7 +69,7 @@ export default function RequestsList(props: RequestsListProps) {
           display: "flex",
           flexDirection: "column",
           gap: 1,
-          maxHeight: "88vh",
+          maxHeight: isUserMobile? "42vh" : "88vh",
           overflowY: "scroll",
           "&::-webkit-scrollbar": {
             width: "8px",
@@ -82,7 +85,7 @@ export default function RequestsList(props: RequestsListProps) {
         disablePadding
       >
         {joinRequests.length > 0 && (
-          <ListItem>
+          <ListItem disablePadding>
             <List
               sx={{
                 width: "100%",
@@ -104,7 +107,7 @@ export default function RequestsList(props: RequestsListProps) {
           </ListItem>
         )}
         {inviteRequests.length > 0 && (
-          <ListItem>
+          <ListItem disablePadding>
             <List
               sx={{
                 width: "100%",

--- a/app/frontend/src/components/Requests/RequestsListItem.tsx
+++ b/app/frontend/src/components/Requests/RequestsListItem.tsx
@@ -55,10 +55,18 @@ export default function RequestsListItem(props: RequestsListItemProps) {
           </Grid>
         </Grid>
         <Grid container size={"auto"} columnSpacing={1}>
-          <IconButton color="success" onClick={accept}>
+          <IconButton
+            color="success"
+            onClick={accept}
+            sx={{ height: "40px", width: "40px" }}
+          >
             <CheckIcon />
           </IconButton>
-          <IconButton color="error" onClick={decline}>
+          <IconButton
+            color="error"
+            onClick={decline}
+            sx={{ height: "40px", width: "40px" }}
+          >
             <CloseIcon />
           </IconButton>
         </Grid>

--- a/app/frontend/src/components/Sidebar/ChatListItem.tsx
+++ b/app/frontend/src/components/Sidebar/ChatListItem.tsx
@@ -41,8 +41,6 @@ export default function ChatListItem(props: IChatListItemProps) {
         throw new Error("Failed to fetch last seen data");
       }
       const data = await response.json();
-      console.log("FETCHING TIMESTAMP:");
-      console.log(data);
       setLastSeen(data.last_seen);
     } catch (error) {
       console.error("Error fetching last seen:", error);

--- a/app/frontend/src/components/Sidebar/SideBar.tsx
+++ b/app/frontend/src/components/Sidebar/SideBar.tsx
@@ -11,53 +11,37 @@ import {
   Grid2 as Grid,
   IconButton,
   List,
+  ListItem,
   SwipeableDrawer,
   Tooltip,
-  ListItem,
 } from "@mui/material";
 
 import { ITeamModel, UserActivity } from "../../models/models";
 
-import { useState } from "react";
+import GroupsIcon from "@mui/icons-material/Groups";
+import { useNavigate } from "react-router-dom";
 import { useApplicationStore, ViewModes } from "../../stores/ApplicationStore";
 import { useUserStore } from "../../stores/UserStore";
 import "../../styles/SideBar.css";
+import { activitySubmit } from "../../utils/ActivityUtils";
 import CreateTeamButton from "../Buttons/CreateTeamButton";
 import SideBarSecondaryPanel from "./SideBarSecondaryPanel";
-import GroupsIcon from "@mui/icons-material/Groups";
-import { activitySubmit } from "../../utils/ActivityUtils";
-import { useNavigate } from "react-router-dom";
 
 interface ISideBarProps {
   drawerVariant: "permanent" | "persistent" | "temporary";
-  drawerOpen: boolean;
-  handleDrawerToggle: () => void;
+  isDrawerOpen: boolean;
+  setIsDrawerOpen: (isDrawerOpen: boolean) => void;
   isUserAdmin: boolean;
 }
 
 export default function SideBar(props: ISideBarProps) {
   const DRAWER_WIDTH = 350;
 
-  const [isDrawerOpen, setIsDrawerOpen] = useState<boolean>(false);
-
   const applicationState = useApplicationStore();
 
   const setIsLoggedIn = useUserStore((state) => state.setIsLoggedIn);
 
   const navigate = useNavigate();
-
-  const toggleDrawer =
-    (open: boolean) => (event: React.KeyboardEvent | React.MouseEvent) => {
-      if (
-        event &&
-        event.type === "keydown" &&
-        ((event as React.KeyboardEvent).key === "Tab" ||
-          (event as React.KeyboardEvent).key === "Shift")
-      ) {
-        return;
-      }
-      setIsDrawerOpen(open);
-    };
 
   const handleLogOut = () => {
     activitySubmit(UserActivity.Offline);
@@ -74,22 +58,31 @@ export default function SideBar(props: ISideBarProps) {
     applicationState.setSelectedTeam(team);
   };
 
+  // check for iOS because they have swipe-to navigate back
+  // solution provided by MUI https://mui.com/material-ui/react-drawer/#swipeable
+  const iOS =
+    typeof navigator !== "undefined" &&
+    /iPad|iPhone|iPod/.test(navigator.userAgent);
+
   return (
     <SwipeableDrawer
+      disableSwipeToOpen={iOS}
+      disableBackdropTransition={!iOS}
       variant={props.drawerVariant}
-      open={isDrawerOpen}
-      onOpen={toggleDrawer(true)}
-      onClose={toggleDrawer(false)}
+      open={props.isDrawerOpen}
+      onOpen={() => props.setIsDrawerOpen(true)}
+      onClose={() => props.setIsDrawerOpen(false)}
       ModalProps={{
         keepMounted: true,
       }}
-      // swipeAreaWidth={60}
+      swipeAreaWidth={50}
       sx={{
         minWidth: DRAWER_WIDTH,
         flexShrink: 0,
         "& .MuiDrawer-paper": {
           width: DRAWER_WIDTH,
-          backgroundColor: "transparent",
+          backgroundColor:
+            props.drawerVariant === "permanent" ? "transparent" : "#324a39",
         },
       }}
     >

--- a/app/frontend/src/components/Sidebar/SideBar.tsx
+++ b/app/frontend/src/components/Sidebar/SideBar.tsx
@@ -80,7 +80,7 @@ export default function SideBar(props: ISideBarProps) {
       ModalProps={{
         keepMounted: true,
       }}
-      swipeAreaWidth={60}
+      // swipeAreaWidth={60}
       sx={{
         minWidth: DRAWER_WIDTH,
         flexShrink: 0,

--- a/app/frontend/src/components/Sidebar/TeamSidebarContent.tsx
+++ b/app/frontend/src/components/Sidebar/TeamSidebarContent.tsx
@@ -36,6 +36,7 @@ export default function TeamSidebarContent() {
                 height: "calc(100vh - 160px)",
                 overflowY: "scroll",
                 scrollbarWidth: "none", // firefox
+                // justifyItems: "center",
                 "&::-webkit-scrollbar": {
                   display: "none", // chrome, safari, opera
                 },
@@ -47,7 +48,8 @@ export default function TeamSidebarContent() {
                   <Button
                     variant={"outlined"}
                     sx={{
-                      width: "95%",
+                      width: "94%",
+                      mx: "8px",
                       backgroundColor: "rgba(34, 34, 34, 0.5)",
                     }}
                     onClick={() => setDisplayPublic(!displayPublic)}
@@ -84,7 +86,8 @@ export default function TeamSidebarContent() {
                     disableFocusRipple
                     variant={"outlined"}
                     sx={{
-                      width: "95%",
+                      width: "94%",
+                      mx: "8px",
                       backgroundColor: "rgba(34, 34, 34, 0.5)",
                     }}
                     onClick={() => setDisplayPrivate(!displayPrivate)}

--- a/app/frontend/src/components/UserListItem.tsx
+++ b/app/frontend/src/components/UserListItem.tsx
@@ -59,8 +59,6 @@ export default function UserListItem(props: IUserListItemProps) {
         throw new Error("Failed to fetch last seen data");
       }
       const data = await response.json();
-      console.log("FETCHING TIMESTAMP:");
-      console.log(data);
       setLastSeen(data.last_seen);
     } catch (error) {
       console.error("Error fetching last seen:", error);

--- a/app/frontend/src/pages/HomePage.tsx
+++ b/app/frontend/src/pages/HomePage.tsx
@@ -1,17 +1,16 @@
 import { Box, useMediaQuery, useTheme } from "@mui/material";
 
-import { useEffect, useState, useRef } from "react";
-import SideBar from "../components/Sidebar/SideBar";
-import { UserActivity, ITeamModel, IUserModel } from "../models/models";
 import Cookies from "js-cookie";
+import { useEffect, useRef, useState } from "react";
+import SideBar from "../components/Sidebar/SideBar";
+import { ITeamModel, IUserModel, UserActivity } from "../models/models";
 
+import { useNavigate } from "react-router-dom";
 import wretch from "wretch";
 import ChatArea from "../components/Chat/ChatArea";
 import { useApplicationStore } from "../stores/ApplicationStore";
-import { useNavigate } from "react-router-dom";
 import { useUserStore } from "../stores/UserStore";
 import { API_URL } from "../utils/FetchUtils";
-import { activitySubmit } from "../utils/ActivityUtils";
 
 export default function HomePage() {
   const theme = useTheme();
@@ -21,9 +20,62 @@ export default function HomePage() {
   const applicationState = useApplicationStore();
   const userState = useUserStore();
 
+  const navigate = useNavigate();
+  const [activity, setActivity] = useState<string>(UserActivity.Online);
+  const lastUpdate = useRef<Date | undefined>(undefined);
+  const setupActivityListeners = () => {
+    document.addEventListener("keydown", activitySubmitOnline);
+    document.addEventListener("click", activitySubmitOnline);
+  };
+
+  const removeActivityListeners = () => {
+    document.removeEventListener("keydown", activitySubmitOnline);
+    document.removeEventListener("click", activitySubmitOnline);
+  };
+
+  const activitySubmitOnline = () => {
+    activitySubmit(UserActivity.Online);
+  };
+
+  const activitySubmit = (status: string) => {
+    if (
+      !(activity === "Online" && status === "Offline") &&
+      Date.now() -
+        (lastUpdate.current
+          ? lastUpdate.current.getTime()
+          : Date.now() - 10000) <
+        1000
+    )
+      return;
+    setActivity(status);
+    lastUpdate.current = new Date(Date.now());
+    wretch(`${API_URL}/api/home/activity`)
+      .auth(`Bearer ${localStorage.getItem("jwt-token")}`)
+      .post({ Activity: status })
+      .res(() => {
+        if (status == "Offline") {
+          window.location.reload();
+          setTimeout(() => {
+            Cookies.remove("isLoggedIn");
+            localStorage.removeItem("jwt-token");
+            userState.setIsLoggedIn(false);
+            navigate("/login");
+          }, 100);
+        }
+      })
+      .catch((error) => {
+        console.error("Error submitting activity:", error);
+      });
+  };
   // use effect with empty dependency array only runs once - on mount.
   useEffect(() => {
+    setupActivityListeners();
     fetchTeamAndChannelData();
+
+    // runs on component unmount
+    return () => {
+      removeActivityListeners();
+    };
   }, []);
 
   const fetchTeamAndChannelData = () => {
@@ -55,7 +107,7 @@ export default function HomePage() {
   };
 
   const [isDrawerOpen, setIsDrawerOpen] = useState(false);
-  
+
   const handleDrawerToggle = () => {
     setIsDrawerOpen(!isDrawerOpen);
   };

--- a/app/frontend/src/pages/HomePage.tsx
+++ b/app/frontend/src/pages/HomePage.tsx
@@ -1,8 +1,4 @@
-import {
-  Box,
-  useMediaQuery,
-  useTheme
-} from "@mui/material";
+import { Box, useMediaQuery, useTheme } from "@mui/material";
 
 import { useEffect, useState, useRef } from "react";
 import SideBar from "../components/Sidebar/SideBar";
@@ -58,10 +54,10 @@ export default function HomePage() {
     );
   };
 
-  const [drawerOpen, setDrawerOpen] = useState(false);
+  const [isDrawerOpen, setIsDrawerOpen] = useState(false);
+  
   const handleDrawerToggle = () => {
-    console.log(drawerOpen);
-    setDrawerOpen(!drawerOpen);
+    setIsDrawerOpen(!isDrawerOpen);
   };
 
   const drawerVariant = isBrowser ? "permanent" : "temporary";
@@ -77,8 +73,8 @@ export default function HomePage() {
       <SideBar
         isUserAdmin={Boolean(userState.user?.isAdmin)}
         drawerVariant={drawerVariant}
-        drawerOpen={drawerOpen}
-        handleDrawerToggle={handleDrawerToggle}
+        isDrawerOpen={isDrawerOpen}
+        setIsDrawerOpen={setIsDrawerOpen}
       />
       <ChatArea
         isUserAdmin={Boolean(userState.user?.isAdmin)}

--- a/app/frontend/src/pages/HomePage.tsx
+++ b/app/frontend/src/pages/HomePage.tsx
@@ -1,14 +1,19 @@
-import { Box, useMediaQuery, useTheme } from "@mui/material";
+import {
+  Box,
+  useMediaQuery,
+  useTheme
+} from "@mui/material";
 
 import { useEffect, useState } from "react";
 import SideBar from "../components/Sidebar/SideBar";
-import { UserActivity, ITeamModel, IUserModel } from "../models/models";
+import { ITeamModel, IUserModel, UserActivity } from "../models/models";
 
 import wretch from "wretch";
 import ChatArea from "../components/Chat/ChatArea";
 import { useApplicationStore } from "../stores/ApplicationStore";
 import { useUserStore } from "../stores/UserStore";
 import { API_URL } from "../utils/FetchUtils";
+
 
 export default function HomePage() {
   const theme = useTheme();
@@ -21,20 +26,29 @@ export default function HomePage() {
   const [lastUpdate, setLastUpdate] = useState<Date>();
 
   const updateActivity = () => {
-    if (Date.now() - (lastUpdate?.getTime() ?? Date.now() - 10000) < 1000) return;
+    if (Date.now() - (lastUpdate?.getTime() ?? Date.now() - 10000) < 1000)
+      return;
     setActivity(UserActivity.Online);
     activitySubmit(UserActivity.Online);
     setLastUpdate(new Date(Date.now()));
-  }
+  };
 
   const setupActivityListeners = () => {
-    document.addEventListener("keydown", () => {updateActivity();});
-    document.addEventListener("click", () => {updateActivity();});
+    document.addEventListener("keydown", () => {
+      updateActivity();
+    });
+    document.addEventListener("click", () => {
+      updateActivity();
+    });
   };
 
   const removeActivityListeners = () => {
-    document.removeEventListener("keydown", () => {updateActivity();});
-    document.removeEventListener("click", () => {updateActivity();});
+    document.removeEventListener("keydown", () => {
+      updateActivity();
+    });
+    document.removeEventListener("click", () => {
+      updateActivity();
+    });
   };
 
   const activitySubmit = (status: string) => {
@@ -90,6 +104,7 @@ export default function HomePage() {
 
   const [drawerOpen, setDrawerOpen] = useState(false);
   const handleDrawerToggle = () => {
+    console.log(drawerOpen);
     setDrawerOpen(!drawerOpen);
   };
 
@@ -113,7 +128,10 @@ export default function HomePage() {
           activitySubmit(UserActivity.Offline);
         }}
       />
-      <ChatArea isUserAdmin={Boolean(userState.user?.isAdmin)} />
+      <ChatArea
+        isUserAdmin={Boolean(userState.user?.isAdmin)}
+        toggleSidebar={handleDrawerToggle}
+      />{" "}
     </Box>
   );
 }

--- a/app/frontend/src/pages/LandingPage.tsx
+++ b/app/frontend/src/pages/LandingPage.tsx
@@ -60,7 +60,7 @@ export default function LandingPage() {
       {/* Features Section */}
       <Container maxWidth='lg' sx={{ py: 10, background: 'linear-gradient(to bottom, #769B86, #A1B1A1)', borderRadius: 4, mt: -5, width: '100vw' }}>
         <Grid container spacing={4}>
-          <Grid size={4}>
+          <Grid size={{xs: 12, md: 4}}>
             <Typography variant='h5' fontWeight='bold'>
               Real-Time Group Chats
             </Typography>
@@ -68,7 +68,7 @@ export default function LandingPage() {
               Communicate instantly with your team and community.
             </Typography>
           </Grid>
-          <Grid size={4}>
+          <Grid size={{xs: 12, md: 4}}>
             <Typography variant='h5' fontWeight='bold'>
               Private Communication
             </Typography>
@@ -76,7 +76,7 @@ export default function LandingPage() {
               Chat one-on-one with your friends and coworkers securely.
             </Typography>
           </Grid>
-          <Grid size={4}>
+          <Grid size={{xs: 12, md: 4}}>
             <Typography variant='h5' fontWeight='bold'>
               Enjoy the Experience
             </Typography>

--- a/app/frontend/src/styles/SideBar.css
+++ b/app/frontend/src/styles/SideBar.css
@@ -72,3 +72,8 @@
     height: 52px;
   }
 }
+
+/* Make MUI's swipeable area not cover the open button */
+.PrivateSwipeArea-root{
+  top: 70px !important; 
+}

--- a/app/frontend/src/utils/BrowserUtils.ts
+++ b/app/frontend/src/utils/BrowserUtils.ts
@@ -1,0 +1,6 @@
+import { useMediaQuery, useTheme } from "@mui/material";
+
+export function isMobile() {
+  const theme = useTheme();
+  return useMediaQuery(theme.breakpoints.down("sm"));
+}

--- a/app/frontend/src/utils/TooltipUtils.ts
+++ b/app/frontend/src/utils/TooltipUtils.ts
@@ -1,0 +1,5 @@
+export const disablePortalSlotProps = {
+  popper: {
+    disablePortal: true, // fix for tooltips staying rendered on fast scroll because of fixed framerate
+  },
+};

--- a/app/frontend/tests/Sidebar.test.tsx
+++ b/app/frontend/tests/Sidebar.test.tsx
@@ -23,13 +23,13 @@ vi.mock("react-router-dom", async () => {
 });
 
 describe("SideBar", () => {
-  const mockHandleDrawerToggle = vi.fn();
+  const mockSetIsDrawerOpen = vi.fn();
   const mockNavigate = vi.fn();
 
   const defaultProps = {
     drawerVariant: "permanent" as "permanent",
-    drawerOpen: true,
-    handleDrawerToggle: mockHandleDrawerToggle,
+    isDrawerOpen: true,
+    setIsDrawerOpen: mockSetIsDrawerOpen,
     isUserAdmin: true,
   };
 


### PR DESCRIPTION
# Mobile rework

Overall, our mobile view is a lot more reliable.
- Dashboard requests list and user list now stacked and are limited on the dashboard.
    - A better solution would probably be to split them into different views, or have them be part of the same combined accordion.
- A top header bar is visible for mobile users (screens that have widths inferior to 600px). This allows users to access the sidebar without relying on swipe to open.
- Swipe to open *should* work in theory on iOS now. I don't own an iOS device. can't test :(
    - Swipe to open might break after one instance of opening it. Not sure exactly why that happens
- The chatbars are now fixed in position when in mobile view.
- Landing page's features section was slightly adjusted.

## Other changes
- Re-added Michael's (@Mikachupichu) fix for activity endpoint being spammed, with a minor tweak to have the event listener be removed correctly when you click log out.

Resolves #220 

## Screenshots
![image](https://github.com/user-attachments/assets/e5080fa3-c9f5-440d-a460-4641c48afd6a)

![image](https://github.com/user-attachments/assets/a39ffcf1-857e-4d01-b1e9-cbe63bb03794)

![image](https://github.com/user-attachments/assets/b331d133-15a5-4d1e-a429-24bc7bacf883)

![image](https://github.com/user-attachments/assets/dec21708-26ac-4f73-8b50-64c9a6225c64)

![image](https://github.com/user-attachments/assets/7b02b23e-9a4f-419f-a1cc-f68998cf2796)

![image](https://github.com/user-attachments/assets/24fd22a4-e373-4b14-b2d8-d96fc7cd11ca)
